### PR TITLE
refactor: move patch archive creation into package.sh

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -51,13 +51,7 @@ jobs:
       - name: Build plugin package
         run: |
           ./package.sh
-          ls -lh /tmp/kobo.koplugin.zip
-
-      - name: Create patches-only archive
-        run: |
-          cd patches
-          zip -r /tmp/kobo-patches.zip .
-          cd ..
+          ls -lh /tmp/kobo.koplugin.zip /tmp/kobo-patches.zip
 
       - name: Upload kobo.koplugin artifact
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,7 @@ jobs:
       - name: Build plugin package
         run: |
           ./package.sh
-          ls -lh /tmp/kobo.koplugin.zip
-
-      - name: Create patches-only archive
-        run: |
-          cd patches
-          zip -r /tmp/kobo-patches.zip .
-          cd ..
+          ls -lh /tmp/kobo.koplugin.zip /tmp/kobo-patches.zip
 
       - name: Generate checksums
         run: |

--- a/package.sh
+++ b/package.sh
@@ -59,8 +59,21 @@ cd - > /dev/null
 # Copy ZIP to output directory
 cp "$WORK_DIR/$PLUGIN_NAME.koplugin.zip" "$OUTPUT_DIR/"
 
+# Copy patches-only folder
+echo "Creating patches-only folder..."
+rm -rf "$OUTPUT_DIR/kobo-patches"
+cp -r "$WORK_DIR/$PLUGIN_NAME.koplugin/patches" "$OUTPUT_DIR/kobo-patches"
+
+# Create patches-only archive
+echo "Creating patches-only archive..."
+cd "$WORK_DIR/$PLUGIN_NAME.koplugin/patches"
+zip -r "$OUTPUT_DIR/kobo-patches.zip" . > /dev/null 2>&1 || true
+cd - > /dev/null
+
 echo ""
 echo "✓ Packaging complete!"
 echo "Output location: $OUTPUT_DIR"
 echo "  - Raw folder: $OUTPUT_DIR/$PLUGIN_NAME.koplugin/"
 echo "  - ZIP archive: $OUTPUT_DIR/$PLUGIN_NAME.koplugin.zip"
+echo "  - Patches folder: $OUTPUT_DIR/kobo-patches/"
+echo "  - Patches archive: $OUTPUT_DIR/kobo-patches.zip"


### PR DESCRIPTION
Refactors workflow scripts to remove repeated patch archive creation steps, delegating this responsibility to the package.sh script. This makes manual packaging easier and keeps artifact generation consistent.

- Removes patch archive creation from workflow YAML files
- Adds patch archive creation to package.sh script
- Allows manual invocation of package.sh for both artifacts

Change-Id: f79ade017792bf416bae3211dc033168
Change-Id-Short: ksqpmlzyssqx