### PR TITLE
chore: add YAML front matter to lua instructions doc

### DIFF
--- a/.github/instructions/lua.md
+++ b/.github/instructions/lua.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**/*.lua"
+---
+
 # Lua Coding Guidelines
 
 ## Formatting Standards

--- a/.github/instructions/markdown.md
+++ b/.github/instructions/markdown.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**/*.md"
+---
+
 # Markdown Formatting Guidelines
 
 ## Overview

--- a/.github/instructions/shell.md
+++ b/.github/instructions/shell.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**/*.sh"
+---
+
 # Shell Script Coding Guidelines
 
 ## Formatting Standards


### PR DESCRIPTION
Added YAML front matter to the lua.md instructions file to specify that the instructions apply to all Lua files.

- Introduced 'applyTo' field targeting all .lua files
- Ensured consistent metadata format with other instruction files

Change-Id: 5cfd064faa65a2a8243011c5a552e606
Change-Id-Short: unkmztvkpptu