### PR TITLE
docs: add site and repository metadata to book config

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,7 @@ command = "mdbook-mermaid"
 
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+site-url = "/kobo.koplugin/"
+git-repository-url = "https://github.com/OGKevin/kobo.koplugin"
+git-repository-icon = "fa-github"
+edit-url-template = "https://github.com/OGKevin/kobo.koplugin/edit/main/{path}"


### PR DESCRIPTION
Added site URL, repository URL, repository icon, and edit URL template to the book.toml configuration for improved documentation navigation.

- Set site-url for correct site root
- Added git-repository-url for source linking
- Specified git-repository-icon for UI display
- Provided edit-url-template for easy doc editing

Change-Id: b744f2653a910bc09266d75f18b3be8f
Change-Id-Short: osvvkxtuwpqy