### PR TITLE
docs: improve reference to available Bluetooth actions

### DIFF
--- a/docs/features/bluetooth.md
+++ b/docs/features/bluetooth.md
@@ -35,9 +35,10 @@ To configure key bindings for a device:
    action.
 6. Repeat from step 3 for other actions you want to configure.
 
-The available actions are defined in `src/lib/bluetooth/available_actions.lua`. If an action you
-need is missing, you can contribute by adding it to this file following the same pattern as existing
-actions. See the plugin development documentation for details.
+The available actions are defined in
+[`src/lib/bluetooth/available_actions.lua`](https://github.com/OGKevin/kobo.koplugin/blob/main/src/lib/bluetooth/available_actions.lua).
+If an action you need is missing, you can contribute by adding it to this file following the same
+pattern as existing actions. See the plugin development documentation for details.
 
 Supported actions include:
 


### PR DESCRIPTION
Clarifies the location of available Bluetooth actions by linking directly to the relevant source file in the repository.

- Adds a Markdown link to available_actions.lua for easier access

Change-Id: 45291262a9ecf15b64fb63a6c38ce4ea
Change-Id-Short: vuxqyxtxpqln