### PR TITLE
docs: add Kobo Elipsa 2E to supported Bluetooth devices

### DIFF
--- a/docs/features/bluetooth.md
+++ b/docs/features/bluetooth.md
@@ -8,6 +8,7 @@ KOReader.
 
 - Kobo Libra Colour
 - Kobo Clara BW / Colour
+- Kobo Elipsa 2E
 
 ## How to use
 


### PR DESCRIPTION
Added Kobo Elipsa 2E to the list of devices supporting Bluetooth in the documentation.

Change-Id: f9768b0454be213d137bc13d334f90da
Change-Id-Short: kqstrozvuvol