### PR TITLE
fix(bluetooth): show configure keys button only when connected

### DIFF
--- a/src/kobo_bluetooth.lua
+++ b/src/kobo_bluetooth.lua
@@ -460,17 +460,20 @@ function KoboBluetooth:showDeviceOptionsMenu(device_info)
     local options = {
         show_connect = not device_info.connected,
         show_disconnect = device_info.connected,
-        show_configure_keys = self.key_bindings ~= nil,
+        show_configure_keys = self.key_bindings ~= nil and device_info.connected,
+
         on_connect = function()
             self.device_manager:connectDevice(device_info, function(dev)
                 self.input_handler:openIsolatedInputDevice(dev, true, true)
             end)
         end,
+
         on_disconnect = function()
             self.device_manager:disconnectDevice(device_info, function(dev)
                 self.input_handler:closeIsolatedInputDevice(dev)
             end)
         end,
+
         on_configure_keys = function()
             if self.key_bindings then
                 self.key_bindings:showConfigMenu(device_info)


### PR DESCRIPTION
Ensure the "Configure key bindings" button is displayed only when the device is connected and key_bindings are available. Previously, the button could appear even if the device was disconnected.

- Update show_configure_keys logic to require device_info.connected
- Prevent configure button from showing for disconnected devices

Change-Id: c059de0f6982dfd7ec9a0a55bba4c9cc
Change-Id-Short: nzuqmlzktqrx