### PR TITLE
fix(bluetooth): add refresh button to scan results menu

### DIFF
--- a/src/kobo_bluetooth.lua
+++ b/src/kobo_bluetooth.lua
@@ -270,6 +270,9 @@ function KoboBluetooth:scanAndShowDevices()
                 self:syncPairedDevicesToSettings()
 
                 self:registerDeviceWithDispatcher(device_info)
+            end, function(menu_widget)
+                UIManager:close(menu_widget)
+                self:scanAndShowDevices()
             end)
         end
     end)

--- a/src/lib/bluetooth/ui_menus.lua
+++ b/src/lib/bluetooth/ui_menus.lua
@@ -49,6 +49,7 @@ end
 -- @param devices table Array of device information from scanForDevices
 -- @param on_device_select function Callback when device is selected, receives device_info
 -- @param on_refresh function Optional callback when refresh button is tapped, receives menu_widget
+-- @return table The created menu widget, or nil if no devices to show
 function UiMenus.showScanResults(devices, on_device_select, on_refresh)
     local reachable_devices = _filterReachableDevices(devices)
     local named_devices = _filterNamedDevices(reachable_devices)

--- a/src/lib/bluetooth/ui_menus.lua
+++ b/src/lib/bluetooth/ui_menus.lua
@@ -48,7 +48,8 @@ end
 -- Devices are sorted by signal strength (strongest first).
 -- @param devices table Array of device information from scanForDevices
 -- @param on_device_select function Callback when device is selected, receives device_info
-function UiMenus.showScanResults(devices, on_device_select)
+-- @param on_refresh function Optional callback when refresh button is tapped, receives menu_widget
+function UiMenus.showScanResults(devices, on_device_select, on_refresh)
     local reachable_devices = _filterReachableDevices(devices)
     local named_devices = _filterNamedDevices(reachable_devices)
 
@@ -98,6 +99,7 @@ function UiMenus.showScanResults(devices, on_device_select)
         covers_fullscreen = true,
         is_borderless = true,
         is_popout = false,
+        title_bar_left_icon = on_refresh and "cre.render.reload" or nil,
 
         onMenuChoice = function(menu_self, item) -- luacheck: ignore menu_self
             if on_device_select then
@@ -114,7 +116,14 @@ function UiMenus.showScanResults(devices, on_device_select)
         end,
     })
 
+    if on_refresh then
+        menu.onLeftButtonTap = function()
+            on_refresh(menu)
+        end
+    end
+
     UIManager:show(menu)
+    return menu
 end
 
 ---


### PR DESCRIPTION
Adds a refresh button to the Bluetooth scan results menu, allowing users to rescan for devices without closing and reopening the menu.

- Adds optional on_refresh callback to UiMenus.showScanResults
- Displays a reload icon if on_refresh is provided
- Calls on_refresh when the left button is tapped
- Updates kobo_bluetooth to rescan and show devices on refresh

Change-Id: 52a3dfbbd82aada58941487d0be0abbb
Change-Id-Short: uxpwmkoomrxp