### PR TITLE
feat(bluetooth): add trust/untrust support for Bluetooth devices

### DIFF
--- a/spec/kobo_bluetooth_spec.lua
+++ b/spec/kobo_bluetooth_spec.lua
@@ -782,6 +782,7 @@ describe("KoboBluetooth", function()
                 name = "Test Device",
                 address = "00:11:22:33:44:55",
                 connected = true,
+                trusted = true,
             }
 
             instance.device_manager.paired_devices_cache = {
@@ -789,6 +790,7 @@ describe("KoboBluetooth", function()
                     name = "Test Device",
                     address = "00:11:22:33:44:55",
                     connected = true,
+                    trusted = true,
                 },
             }
 
@@ -797,14 +799,15 @@ describe("KoboBluetooth", function()
 
             instance:refreshDeviceOptionsMenu(mock_menu, device_info)
 
-            -- New dialog should have 3 button rows: Disconnect, Configure key bindings, and Forget
+            -- New dialog should have 4 button rows: Disconnect, Configure key bindings, Untrust, and Forget
             local new_dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
             assert.is_not_nil(new_dialog)
             assert.is_not_nil(new_dialog.buttons)
-            assert.are.equal(3, #new_dialog.buttons)
+            assert.are.equal(4, #new_dialog.buttons)
             assert.are.equal("Disconnect", new_dialog.buttons[1][1].text)
             assert.are.equal("Configure key bindings", new_dialog.buttons[2][1].text)
-            assert.are.equal("Forget", new_dialog.buttons[3][1].text)
+            assert.are.equal("Untrust", new_dialog.buttons[3][1].text)
+            assert.are.equal("Forget", new_dialog.buttons[4][1].text)
         end)
 
         it("should not show configure button when device is disconnected", function()
@@ -826,6 +829,7 @@ describe("KoboBluetooth", function()
                 name = "Test Device",
                 address = "00:11:22:33:44:55",
                 connected = false,
+                trusted = true,
             }
 
             instance.device_manager.paired_devices_cache = {
@@ -833,6 +837,7 @@ describe("KoboBluetooth", function()
                     name = "Test Device",
                     address = "00:11:22:33:44:55",
                     connected = false,
+                    trusted = true,
                 },
             }
 
@@ -841,13 +846,14 @@ describe("KoboBluetooth", function()
 
             instance:refreshDeviceOptionsMenu(mock_menu, device_info)
 
-            -- New dialog should have 2 button rows: Connect and Forget (no configure when disconnected)
+            -- New dialog should have 3 button rows: Connect, Untrust, and Forget (no configure when disconnected)
             local new_dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
             assert.is_not_nil(new_dialog)
             assert.is_not_nil(new_dialog.buttons)
-            assert.are.equal(2, #new_dialog.buttons)
+            assert.are.equal(3, #new_dialog.buttons)
             assert.are.equal("Connect", new_dialog.buttons[1][1].text)
-            assert.are.equal("Forget", new_dialog.buttons[2][1].text)
+            assert.are.equal("Untrust", new_dialog.buttons[2][1].text)
+            assert.are.equal("Forget", new_dialog.buttons[3][1].text)
         end)
 
         it("should handle device not found in paired devices", function()
@@ -898,6 +904,7 @@ describe("KoboBluetooth", function()
                 name = "Test Device",
                 address = "00:11:22:33:44:55",
                 connected = true,
+                trusted = true,
             }
 
             instance.device_manager.paired_devices_cache = {
@@ -905,6 +912,7 @@ describe("KoboBluetooth", function()
                     name = "Test Device",
                     address = "00:11:22:33:44:55",
                     connected = true,
+                    trusted = true,
                 },
             }
 
@@ -913,15 +921,16 @@ describe("KoboBluetooth", function()
 
             instance:refreshDeviceOptionsMenu(mock_menu, device_info)
 
-            -- New dialog should have 3 button rows: Disconnect, Configure key bindings, and Forget
+            -- New dialog should have 4 button rows: Disconnect, Configure key bindings, Untrust, and Forget
             local new_dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
             assert.is_not_nil(new_dialog)
             assert.is_not_nil(new_dialog.buttons)
-            assert.are.equal(3, #new_dialog.buttons)
+            assert.are.equal(4, #new_dialog.buttons)
             assert.are.equal("Disconnect", new_dialog.buttons[1][1].text)
             assert.is_not_nil(new_dialog.buttons[1][1].callback)
             assert.are.equal("Configure key bindings", new_dialog.buttons[2][1].text)
-            assert.are.equal("Forget", new_dialog.buttons[3][1].text)
+            assert.are.equal("Untrust", new_dialog.buttons[3][1].text)
+            assert.are.equal("Forget", new_dialog.buttons[4][1].text)
         end)
 
         it("should call removeDevice when forget button is clicked", function()
@@ -1016,6 +1025,7 @@ describe("KoboBluetooth", function()
                 name = "Test Device",
                 address = "00:11:22:33:44:55",
                 connected = true,
+                trusted = true,
             }
 
             instance:showDeviceOptionsMenu(device_info)
@@ -1024,12 +1034,13 @@ describe("KoboBluetooth", function()
             assert.is_not_nil(dialog)
             assert.is_not_nil(dialog.buttons)
 
-            -- Should have 4 buttons: Disconnect, Configure key bindings, Reset key bindings, Forget
-            assert.are.equal(4, #dialog.buttons)
+            -- Should have 5 buttons: Disconnect, Configure key bindings, Untrust, Reset key bindings, Forget
+            assert.are.equal(5, #dialog.buttons)
             assert.are.equal("Disconnect", dialog.buttons[1][1].text)
             assert.are.equal("Configure key bindings", dialog.buttons[2][1].text)
-            assert.are.equal("Reset key bindings", dialog.buttons[3][1].text)
-            assert.are.equal("Forget", dialog.buttons[4][1].text)
+            assert.are.equal("Untrust", dialog.buttons[3][1].text)
+            assert.are.equal("Reset key bindings", dialog.buttons[4][1].text)
+            assert.are.equal("Forget", dialog.buttons[5][1].text)
         end)
 
         it("should not show reset keybindings button when device has no key bindings", function()
@@ -1050,6 +1061,7 @@ describe("KoboBluetooth", function()
                 name = "Test Device",
                 address = "00:11:22:33:44:55",
                 connected = true,
+                trusted = true,
             }
 
             instance:showDeviceOptionsMenu(device_info)
@@ -1058,11 +1070,12 @@ describe("KoboBluetooth", function()
             assert.is_not_nil(dialog)
             assert.is_not_nil(dialog.buttons)
 
-            -- Should have 3 buttons: Disconnect, Configure key bindings, Forget (no reset button)
-            assert.are.equal(3, #dialog.buttons)
+            -- Should have 4 buttons: Disconnect, Configure key bindings, Untrust, Forget (no reset button)
+            assert.are.equal(4, #dialog.buttons)
             assert.are.equal("Disconnect", dialog.buttons[1][1].text)
             assert.are.equal("Configure key bindings", dialog.buttons[2][1].text)
-            assert.are.equal("Forget", dialog.buttons[3][1].text)
+            assert.are.equal("Untrust", dialog.buttons[3][1].text)
+            assert.are.equal("Forget", dialog.buttons[4][1].text)
         end)
 
         it("should call clearDeviceBindings when reset keybindings button is clicked", function()
@@ -1132,6 +1145,238 @@ describe("KoboBluetooth", function()
 
             assert.is_true(clear_bindings_called)
             assert.are.equal("00:11:22:33:44:55", cleared_device_mac)
+        end)
+
+        it("should show Trust button when device is not trusted", function()
+            setMockPopenOutput("variant boolean true")
+
+            local instance = KoboBluetooth:new()
+            instance:initWithPlugin(mock_plugin)
+
+            UIManager:_reset()
+
+            local device_info = {
+                name = "Test Device",
+                address = "00:11:22:33:44:55",
+                connected = false,
+                trusted = false,
+                path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+            }
+
+            instance.device_manager.paired_devices_cache = {
+                {
+                    name = "Test Device",
+                    address = "00:11:22:33:44:55",
+                    connected = false,
+                    trusted = false,
+                    path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+                },
+            }
+
+            instance.device_manager.loadPairedDevices = function(self) end
+
+            instance:showDeviceOptionsMenu(device_info)
+
+            local dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
+            assert.is_not_nil(dialog)
+            assert.is_not_nil(dialog.buttons)
+
+            -- Find the Trust button
+            local trust_button = nil
+            for _, row in ipairs(dialog.buttons) do
+                if row[1].text == "Trust" then
+                    trust_button = row[1]
+                    break
+                end
+            end
+
+            assert.is_not_nil(trust_button)
+
+            -- Untrust button should not be present
+            local untrust_button = nil
+            for _, row in ipairs(dialog.buttons) do
+                if row[1].text == "Untrust" then
+                    untrust_button = row[1]
+                    break
+                end
+            end
+
+            assert.is_nil(untrust_button)
+        end)
+
+        it("should show Untrust button when device is trusted", function()
+            setMockPopenOutput("variant boolean true")
+
+            local instance = KoboBluetooth:new()
+            instance:initWithPlugin(mock_plugin)
+
+            UIManager:_reset()
+
+            local device_info = {
+                name = "Test Device",
+                address = "00:11:22:33:44:55",
+                connected = false,
+                trusted = true,
+                path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+            }
+
+            instance.device_manager.paired_devices_cache = {
+                {
+                    name = "Test Device",
+                    address = "00:11:22:33:44:55",
+                    connected = false,
+                    trusted = true,
+                    path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+                },
+            }
+
+            instance.device_manager.loadPairedDevices = function(self) end
+
+            instance:showDeviceOptionsMenu(device_info)
+
+            local dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
+            assert.is_not_nil(dialog)
+            assert.is_not_nil(dialog.buttons)
+
+            -- Find the Untrust button
+            local untrust_button = nil
+            for _, row in ipairs(dialog.buttons) do
+                if row[1].text == "Untrust" then
+                    untrust_button = row[1]
+                    break
+                end
+            end
+
+            assert.is_not_nil(untrust_button)
+
+            -- Trust button should not be present
+            local trust_button = nil
+            for _, row in ipairs(dialog.buttons) do
+                if row[1].text == "Trust" then
+                    trust_button = row[1]
+                    break
+                end
+            end
+
+            assert.is_nil(trust_button)
+        end)
+
+        it("should call trustDevice when trust button is clicked", function()
+            setMockPopenOutput("variant boolean true")
+
+            local instance = KoboBluetooth:new()
+            instance:initWithPlugin(mock_plugin)
+
+            UIManager:_reset()
+
+            local device_info = {
+                name = "Test Device",
+                address = "00:11:22:33:44:55",
+                connected = false,
+                trusted = false,
+                path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+            }
+
+            instance.device_manager.paired_devices_cache = {
+                {
+                    name = "Test Device",
+                    address = "00:11:22:33:44:55",
+                    connected = false,
+                    trusted = false,
+                    path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+                },
+            }
+
+            instance.device_manager.loadPairedDevices = function(self) end
+
+            local trust_device_called = false
+            local original_trustDevice = instance.device_manager.trustDevice
+
+            instance.device_manager.trustDevice = function(self, device)
+                trust_device_called = true
+
+                return true
+            end
+
+            instance:showDeviceOptionsMenu(device_info)
+
+            local dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
+            assert.is_not_nil(dialog)
+
+            -- Find and click the Trust button
+            local trust_button = nil
+            for _, row in ipairs(dialog.buttons) do
+                if row[1].text == "Trust" then
+                    trust_button = row[1]
+                    break
+                end
+            end
+
+            assert.is_not_nil(trust_button)
+            trust_button.callback()
+
+            assert.is_true(trust_device_called)
+
+            instance.device_manager.trustDevice = original_trustDevice
+        end)
+
+        it("should call untrustDevice when untrust button is clicked", function()
+            setMockPopenOutput("variant boolean true")
+
+            local instance = KoboBluetooth:new()
+            instance:initWithPlugin(mock_plugin)
+
+            UIManager:_reset()
+
+            local device_info = {
+                name = "Test Device",
+                address = "00:11:22:33:44:55",
+                connected = false,
+                trusted = true,
+                path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+            }
+
+            instance.device_manager.paired_devices_cache = {
+                {
+                    name = "Test Device",
+                    address = "00:11:22:33:44:55",
+                    connected = false,
+                    trusted = true,
+                    path = "/org/bluez/hci0/dev_00_11_22_33_44_55",
+                },
+            }
+
+            instance.device_manager.loadPairedDevices = function(self) end
+
+            local untrust_device_called = false
+            local original_untrustDevice = instance.device_manager.untrustDevice
+
+            instance.device_manager.untrustDevice = function(self, device)
+                untrust_device_called = true
+
+                return true
+            end
+
+            instance:showDeviceOptionsMenu(device_info)
+
+            local dialog = UIManager._shown_widgets[#UIManager._shown_widgets]
+            assert.is_not_nil(dialog)
+
+            -- Find and click the Untrust button
+            local untrust_button = nil
+            for _, row in ipairs(dialog.buttons) do
+                if row[1].text == "Untrust" then
+                    untrust_button = row[1]
+                    break
+                end
+            end
+
+            assert.is_not_nil(untrust_button)
+            untrust_button.callback()
+
+            assert.is_true(untrust_device_called)
+
+            instance.device_manager.untrustDevice = original_untrustDevice
         end)
     end)
 

--- a/spec/lib/bluetooth/dbus_adapter_spec.lua
+++ b/spec/lib/bluetooth/dbus_adapter_spec.lua
@@ -260,4 +260,61 @@ describe("DbusAdapter", function()
             )
         end)
     end)
+
+    describe("setDeviceTrusted", function()
+        it("should return true on successful trust operation", function()
+            setMockExecuteResult(0)
+            local result = DbusAdapter.setDeviceTrusted("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", true)
+
+            assert.is_true(result)
+        end)
+
+        it("should return true on successful untrust operation", function()
+            setMockExecuteResult(0)
+            local result = DbusAdapter.setDeviceTrusted("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", false)
+
+            assert.is_true(result)
+        end)
+
+        it("should return false on failed operation", function()
+            setMockExecuteResult(1)
+            local result = DbusAdapter.setDeviceTrusted("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", true)
+
+            assert.is_false(result)
+        end)
+
+        it("should execute correct D-Bus command for trusting", function()
+            setMockExecuteResult(0)
+            clearExecutedCommands()
+
+            DbusAdapter.setDeviceTrusted("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", true)
+
+            local commands = getExecutedCommands()
+            assert.are.equal(1, #commands)
+            assert.is_true(
+                commands[1]:match(
+                    "dbus%-send .* /org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF "
+                        .. "org%.freedesktop%.DBus%.Properties%.Set "
+                        .. "string:org%.bluez%.Device1 string:Trusted variant:boolean:true"
+                ) ~= nil
+            )
+        end)
+
+        it("should execute correct D-Bus command for untrusting", function()
+            setMockExecuteResult(0)
+            clearExecutedCommands()
+
+            DbusAdapter.setDeviceTrusted("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", false)
+
+            local commands = getExecutedCommands()
+            assert.are.equal(1, #commands)
+            assert.is_true(
+                commands[1]:match(
+                    "dbus%-send .* /org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF "
+                        .. "org%.freedesktop%.DBus%.Properties%.Set "
+                        .. "string:org%.bluez%.Device1 string:Trusted variant:boolean:false"
+                ) ~= nil
+            )
+        end)
+    end)
 end)

--- a/spec/lib/bluetooth/device_manager_spec.lua
+++ b/spec/lib/bluetooth/device_manager_spec.lua
@@ -499,4 +499,154 @@ object path "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
             assert.are.equal("AA:BB:CC:DD:EE:FF", devices[1].address)
         end)
     end)
+
+    describe("trustDevice", function()
+        it("should show success message on successful trust", function()
+            setMockExecuteResult(0)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local manager = DeviceManager:new()
+            local result = manager:trustDevice(device)
+
+            assert.is_true(result)
+            assert.are.equal(1, #UIManager._show_calls)
+        end)
+
+        it("should call on_success callback after trusting", function()
+            setMockExecuteResult(0)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local callback_called = false
+            local callback_device = nil
+
+            local manager = DeviceManager:new()
+            manager:trustDevice(device, function(dev)
+                callback_called = true
+                callback_device = dev
+            end)
+
+            assert.is_true(callback_called)
+            assert.are.equal(device, callback_device)
+        end)
+
+        it("should show error message on failed trust", function()
+            setMockExecuteResult(1)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local manager = DeviceManager:new()
+            local result = manager:trustDevice(device)
+
+            assert.is_false(result)
+            assert.are.equal(1, #UIManager._show_calls)
+        end)
+
+        it("should not call on_success callback on failed trust", function()
+            setMockExecuteResult(1)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local callback_called = false
+
+            local manager = DeviceManager:new()
+            manager:trustDevice(device, function()
+                callback_called = true
+            end)
+
+            assert.is_false(callback_called)
+        end)
+    end)
+
+    describe("untrustDevice", function()
+        it("should show success message on successful untrust", function()
+            setMockExecuteResult(0)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local manager = DeviceManager:new()
+            local result = manager:untrustDevice(device)
+
+            assert.is_true(result)
+            assert.are.equal(1, #UIManager._show_calls)
+        end)
+
+        it("should call on_success callback after untrusting", function()
+            setMockExecuteResult(0)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local callback_called = false
+            local callback_device = nil
+
+            local manager = DeviceManager:new()
+            manager:untrustDevice(device, function(dev)
+                callback_called = true
+                callback_device = dev
+            end)
+
+            assert.is_true(callback_called)
+            assert.are.equal(device, callback_device)
+        end)
+
+        it("should show error message on failed untrust", function()
+            setMockExecuteResult(1)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local manager = DeviceManager:new()
+            local result = manager:untrustDevice(device)
+
+            assert.is_false(result)
+            assert.are.equal(1, #UIManager._show_calls)
+        end)
+
+        it("should not call on_success callback on failed untrust", function()
+            setMockExecuteResult(1)
+
+            local device = {
+                path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                name = "Test Device",
+                address = "AA:BB:CC:DD:EE:FF",
+            }
+
+            local callback_called = false
+
+            local manager = DeviceManager:new()
+            manager:untrustDevice(device, function()
+                callback_called = true
+            end)
+
+            assert.is_false(callback_called)
+        end)
+    end)
 end)

--- a/src/kobo_bluetooth.lua
+++ b/src/kobo_bluetooth.lua
@@ -771,6 +771,8 @@ function KoboBluetooth:showDeviceOptionsMenu(device_info)
         show_disconnect = device_info.connected,
         show_configure_keys = self.key_bindings ~= nil and device_info.connected,
         show_reset_keybindings = has_keybindings,
+        show_trust = not device_info.trusted,
+        show_untrust = device_info.trusted,
         show_forget = true,
 
         on_connect = function()
@@ -803,6 +805,15 @@ function KoboBluetooth:showDeviceOptionsMenu(device_info)
                 end,
             }))
         end,
+
+        on_trust = function()
+            self.device_manager:trustDevice(device_info)
+        end,
+
+        on_untrust = function()
+            self.device_manager:untrustDevice(device_info)
+        end,
+
         on_forget = function()
             self.device_manager:removeDevice(device_info, function(dev)
                 self.input_handler:closeIsolatedInputDevice(dev)

--- a/src/lib/bluetooth/dbus_adapter.lua
+++ b/src/lib/bluetooth/dbus_adapter.lua
@@ -205,4 +205,26 @@ function DbusAdapter.removeDevice(device_path)
     return result == 0
 end
 
+---
+-- Sets or clears the Trusted property on a Bluetooth device via D-Bus.
+-- @param device_path string D-Bus object path of the device
+-- @param trusted boolean True to trust the device, false to untrust
+-- @return boolean True if the operation succeeded, false otherwise.
+function DbusAdapter.setDeviceTrusted(device_path, trusted)
+    local trust_str = trusted and "true" or "false"
+    logger.info("DbusAdapter: Setting device trusted:", device_path, "to", trust_str)
+
+    local cmd = string.format(
+        "dbus-send --system --print-reply --dest=com.kobo.mtk.bluedroid %s "
+            .. "org.freedesktop.DBus.Properties.Set "
+            .. "string:org.bluez.Device1 string:Trusted variant:boolean:%s",
+        device_path,
+        trust_str
+    )
+
+    local result = os.execute(cmd)
+
+    return result == 0
+end
+
 return DbusAdapter

--- a/src/lib/bluetooth/device_manager.lua
+++ b/src/lib/bluetooth/device_manager.lua
@@ -188,6 +188,73 @@ function DeviceManager:removeDevice(device, on_success)
 
     return false
 end
+
+---
+-- Sets a device as trusted.
+-- @param device table Device information table with path and name
+-- @param on_success function Optional callback to execute on success
+-- @return boolean True if operation succeeded, false otherwise
+function DeviceManager:trustDevice(device, on_success)
+    logger.info("DeviceManager: Trusting device:", device.name, "path:", device.path)
+
+    if DbusAdapter.setDeviceTrusted(device.path, true) then
+        logger.info("DeviceManager: Successfully trusted", device.name)
+
+        UIManager:show(InfoMessage:new({
+            text = _("Trusted") .. " " .. device.name,
+            timeout = 2,
+        }))
+
+        if on_success then
+            on_success(device)
+        end
+
+        return true
+    end
+
+    logger.warn("DeviceManager: Failed to trust", device.name)
+
+    UIManager:show(InfoMessage:new({
+        text = _("Failed to trust") .. " " .. device.name,
+        timeout = 3,
+    }))
+
+    return false
+end
+
+---
+-- Removes trust from a device.
+-- @param device table Device information table with path and name
+-- @param on_success function Optional callback to execute on success
+-- @return boolean True if operation succeeded, false otherwise
+function DeviceManager:untrustDevice(device, on_success)
+    logger.info("DeviceManager: Untrusting device:", device.name, "path:", device.path)
+
+    if DbusAdapter.setDeviceTrusted(device.path, false) then
+        logger.info("DeviceManager: Successfully untrusted", device.name)
+
+        UIManager:show(InfoMessage:new({
+            text = _("Untrusted") .. " " .. device.name,
+            timeout = 2,
+        }))
+
+        if on_success then
+            on_success(device)
+        end
+
+        return true
+    end
+
+    logger.warn("DeviceManager: Failed to untrust", device.name)
+
+    UIManager:show(InfoMessage:new({
+        text = _("Failed to untrust") .. " " .. device.name,
+        timeout = 3,
+    }))
+
+    return false
+end
+
 ---
 -- Loads paired devices from D-Bus and caches them in memory.
 function DeviceManager:loadPairedDevices()

--- a/src/lib/bluetooth/device_parser.lua
+++ b/src/lib/bluetooth/device_parser.lua
@@ -29,6 +29,7 @@ end
 --   - paired: Boolean indicating if device is paired
 --   - connected: Boolean indicating if device is connected
 --   - rssi: Signal strength in dBm (nil if not available)
+--   - trusted: If the device has been marked as trusted or not
 function DeviceParser.parseDiscoveredDevices(dbus_output)
     local devices = {}
 
@@ -54,6 +55,7 @@ function DeviceParser.parseDiscoveredDevices(dbus_output)
                 name = "",
                 paired = false,
                 connected = false,
+                trusted = false,
                 rssi = nil,
             }
             in_device_section = true
@@ -67,6 +69,8 @@ function DeviceParser.parseDiscoveredDevices(dbus_output)
                 last_property = "Paired"
             elseif line:match('string "Connected"') then
                 last_property = "Connected"
+            elseif line:match('string "Trusted"') then
+                last_property = "Trusted"
             elseif line:match('string "RSSI"') then
                 last_property = "RSSI"
             end
@@ -97,6 +101,13 @@ function DeviceParser.parseDiscoveredDevices(dbus_output)
 
                 if connected_value then
                     current_device.connected = (connected_value == "true")
+                    last_property = nil
+                end
+            elseif last_property == "Trusted" then
+                local trusted_value = line:match("variant%s+boolean (%w+)")
+
+                if trusted_value then
+                    current_device.trusted = (trusted_value == "true")
                     last_property = nil
                 end
             elseif last_property == "RSSI" then

--- a/src/lib/bluetooth/ui_menus.lua
+++ b/src/lib/bluetooth/ui_menus.lua
@@ -198,11 +198,15 @@ end
 --   - show_disconnect: boolean Whether to show disconnect option
 --   - show_configure_keys: boolean Whether to show configure keys option
 --   - show_reset_keybindings: boolean Whether to show reset keybindings option
+--   - show_trust: boolean Whether to show trust option
+--   - show_untrust: boolean Whether to show untrust option
 --   - show_forget: boolean Whether to show forget/unpair option
 --   - on_connect: function Callback for connect action
 --   - on_disconnect: function Callback for disconnect action
 --   - on_configure_keys: function Callback for configure keys action
 --   - on_reset_keybindings: function Callback for reset keybindings action
+--   - on_trust: function Callback for trust action
+--   - on_untrust: function Callback for untrust action
 --   - on_forget: function Callback for forget action
 -- @param on_action_complete function Optional callback when connect/disconnect/forget completes
 function UiMenus.showDeviceOptionsMenu(device_info, options, on_action_complete)
@@ -253,6 +257,38 @@ function UiMenus.showDeviceOptionsMenu(device_info, options, on_action_complete)
         })
     end
 
+    if options.show_trust then
+        table.insert(button_rows, {
+            {
+                text = _("Trust"),
+                callback = function()
+                    UIManager:close(dialog)
+                    options.on_trust()
+
+                    if on_action_complete then
+                        on_action_complete()
+                    end
+                end,
+            },
+        })
+    end
+
+    if options.show_untrust then
+        table.insert(button_rows, {
+            {
+                text = _("Untrust"),
+                callback = function()
+                    UIManager:close(dialog)
+                    options.on_untrust()
+
+                    if on_action_complete then
+                        on_action_complete()
+                    end
+                end,
+            },
+        })
+    end
+
     if options.show_reset_keybindings then
         table.insert(button_rows, {
             {
@@ -264,6 +300,7 @@ function UiMenus.showDeviceOptionsMenu(device_info, options, on_action_complete)
             },
         })
     end
+
     if options.show_forget then
         table.insert(button_rows, {
             {


### PR DESCRIPTION
Add support for trusting and untrusting Bluetooth devices via the UI and D-Bus. Device info now includes a 'trusted' property, and menus show Trust/Untrust buttons based on device state.

- Parse and expose the 'Trusted' property in device info
- Add DeviceManager methods for trustDevice and untrustDevice
- Implement DbusAdapter.setDeviceTrusted for D-Bus calls
- Update UI menus to show Trust/Untrust actions
- Add and update tests for trust/untrust logic

Change-Id: b259ad2db8940061136d76114f93ff58
Change-Id-Short: oxuqpmxmorqv