### PR TITLE
ci: support release branches in workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 permissions:
   contents: write
@@ -21,6 +22,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          target-branch: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:


### PR DESCRIPTION
This change updates the release workflow to trigger on pushes to release/* branches and sets the target branch dynamically using github.ref_name.

- Add release/* to workflow trigger branches
- Set target-branch to github.ref_name in release-please-action

Change-Id: 0619cf5cf81cbab5e403b4ce74e57b73
Change-Id-Short: ztyqnkunkryn