### PR TITLE
docs: add Device Options Menu documentation for Bluetooth

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
     - [Sync Configuration Examples](./settings/sync-configuration-examples.md)
   - [Bluetooth Settings](./settings/bluetooth-settings/index.md)
     - [Paired Devices](./settings/bluetooth-settings/paired-devices.md)
+      - [Device Options Menu](./settings/bluetooth-settings/device-options-menu.md)
     - [Key Bindings](./settings/bluetooth-settings/key-bindings.md)
     - [Auto-resume After Wake](./settings/bluetooth-settings/auto-resume.md)
     - [Footer Status](./settings/bluetooth-settings/footer-status.md)

--- a/docs/settings/bluetooth-settings/device-options-menu.md
+++ b/docs/settings/bluetooth-settings/device-options-menu.md
@@ -1,0 +1,21 @@
+# Device Options Menu
+
+When you select a device from the [Paired Devices](./paired-devices.md) list, a menu appears with
+options for managing that device.
+
+## Accessing the Device Options Menu
+
+1. Navigate to Settings → Network → Bluetooth → Paired devices
+2. Select any device from the list
+
+The options shown depend on the device's current state.
+
+## Available Options
+
+| Option                     | Shows When                                               | Function                                                                                                                                                                                                             |
+| -------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Connect**                | Device is not currently connected                        | Establishes a connection to the device. The device will be ready to use with KOReader once connected. Bluetooth must be enabled.                                                                                     |
+| **Disconnect**             | Device is currently connected                            | Closes the active connection. The device remains paired but will no longer be actively connected. You can reconnect at any time without needing to pair again.                                                       |
+| **Configure Key Bindings** | Device is connected and the plugin supports key bindings | Opens a menu to set up button mappings for remote controls and keyboards. You can assign actions to buttons on your Bluetooth device. See [Key Bindings](./key-bindings.md) for detailed configuration instructions. |
+| **Reset Key Bindings**     | The device has existing key binding configurations       | Removes all button mappings for this device. You'll be asked to confirm before the key bindings are cleared.                                                                                                         |
+| **Forget**                 | Always shown                                             | Removes the device from your paired devices list. This unpairs the device from your Kobo. You'll need to pair it again to use it. The device's key bindings (if any) are also removed.                               |

--- a/docs/settings/bluetooth-settings/index.md
+++ b/docs/settings/bluetooth-settings/index.md
@@ -6,5 +6,6 @@ connect to them, and configure button mappings for Bluetooth remotes and keyboar
 ## Documentation
 
 - **[Paired Devices](./paired-devices.md)**: Managing paired Bluetooth devices and connections
+- **[Device Options Menu](./device-options-menu.md)**: Available actions for individual devices
 - **[Key Bindings](./key-bindings.md)**: Configuring button mappings for Bluetooth devices
 - **[Menu Navigation](./menu.md)**: How to access Bluetooth settings and menu hierarchy reference

--- a/docs/settings/bluetooth-settings/paired-devices.md
+++ b/docs/settings/bluetooth-settings/paired-devices.md
@@ -3,35 +3,12 @@
 The plugin maintains a list of all Bluetooth devices that have been paired with your Kobo, including
 devices paired through Kobo Nickel.
 
-## Viewing Paired Devices
-
-1. Navigate to Settings → Network → Bluetooth → Paired devices You'll see a list of all devices that
-   have been paired with your Kobo.
-
-## Connecting to a Device
+## Accessing Paired Devices
 
 1. Navigate to Settings → Network → Bluetooth → Paired devices
-2. Select the device you want to connect
-3. Choose "Connect"
 
-Once connected, the device will be ready to use with KOReader.
-
-## Disconnecting from a Device
-
-1. Navigate to Settings → Network → Bluetooth → Paired devices
-2. Select the connected device
-3. Choose "Disconnect"
-
-The device remains paired but will no longer be actively connected.
-
-## Forgetting a Paired Device
-
-1. Navigate to Settings → Network → Bluetooth → Paired devices
-2. Select the device you want to forget
-3. Choose "Forget"
-
-This unpairs the device from your Kobo and removes it from the paired devices list. You'll need to
-pair it again to use it.
+You'll see a list of all devices paired with your Kobo. Each device shows its name and current
+connection status.
 
 ## Pairing a New Device
 
@@ -41,12 +18,12 @@ pair it again to use it.
 4. Select your device from the list
 5. Follow any on-screen prompts to complete pairing
 
+## Device Options Menu
+
+Select any device from the paired devices list to open the device options menu. See
+[Device Options Menu](./device-options-menu.md) for details on available actions.
+
 ## Notes
 
-- Devices paired in Kobo Nickel automatically appear in KOReader's paired devices list
-- You can reconnect to any paired device without needing to pair it again
 - Paired devices can only be connected when they are nearby and discoverable. Use "Scan for devices"
-  (Settings → Network → Bluetooth → Scan for devices) to detect nearby devices. This includes new
-  devices to pair as well as previously paired devices that have become discoverable. If a paired
-  device appears in the scan results you can connect to it from the Paired devices list without
-  having to trigger a scan. So remember how to put the device in discoverable mode.
+  to detect nearby devices, including previously paired devices that have become discoverable


### PR DESCRIPTION
Added a new section describing the Device Options Menu available when selecting a paired Bluetooth device. Updated the summary to include the new documentation page.

- Added device-options-menu.md with details on menu options and usage
- Linked Device Options Menu in SUMMARY.md under Bluetooth Settings
- Explained each menu option and its conditions for display

Change-Id: 26c5483c7b1009a901b09fd0525cc978
Change-Id-Short: xtnuvrwnsoyz