### PR TITLE
refactor: centralize default plugin settings in main.lua

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -151,6 +151,10 @@ local default_settings = {
     sync_to_kobo_older = SYNC_DIRECTION.NEVER,
     paired_devices = {},
     enable_bluetooth_auto_resume = false,
+    enable_auto_detection_polling = false,
+    disable_auto_detection_after_connect = true,
+    enable_auto_connect_polling = false,
+    disable_auto_connect_after_connect = true,
 }
 
 local plugin_settings = G_reader_settings:readSetting("kobo_plugin") or default_settings
@@ -174,21 +178,7 @@ local kobo_bluetooth = KoboBluetooth:new()
 local KoboPlugin = WidgetContainer:extend({
     name = "kobo_plugin",
     is_doc_only = false,
-    default_settings = {
-        sync_reading_state = false,
-        enable_auto_sync = false,
-        enable_sync_from_kobo = false,
-        enable_sync_to_kobo = true,
-        sync_from_kobo_newer = SYNC_DIRECTION.PROMPT,
-        sync_from_kobo_older = SYNC_DIRECTION.NEVER,
-        sync_to_kobo_newer = SYNC_DIRECTION.SILENT,
-        sync_to_kobo_older = SYNC_DIRECTION.NEVER,
-        paired_devices = {},
-        enable_auto_detection_polling = false,
-        disable_auto_detection_after_connect = true,
-        enable_auto_connect_polling = false,
-        disable_auto_connect_after_connect = true,
-    },
+    default_settings = default_settings,
 })
 
 ---


### PR DESCRIPTION
Move all default plugin settings into a single shared table to improve maintainability and reduce duplication.

- Added new options to the default_settings table
- Replaced inline default_settings with a reference to the shared table
- Simplified settings management for the plugin

Change-Id: 6057b314afbf1f7dfa797584ff683370
Change-Id-Short: tzusowyvpkok