### PR TITLE
ci(copilot): fix setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,6 +16,9 @@ jobs:
     name: Prepare Copilot Agent Environment
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Add local bins to PATH
         run: |
           mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
Manually checkout the code in the copilot setup workflow to ensure the agent has access to the repository files. This should fix cloning issues when other steps add content to the repo folder.

Change-Id: e94eee357e527ef15d966d610da7250d
Change-Id-Short: lqvlllwuslux