### PR TITLE
chore: update .gitignore for Lua and Luarocks artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ luacov.stats.out
 
 book
 mermaid.min.js
+
+.lua
+.luarocks
+


### PR DESCRIPTION
Added patterns to ignore hidden Lua and Luarocks files and directories. This prevents accidental commits of local development files.

- Added `.lua` and `.luarocks` to ignored patterns  

Change-Id: 3724fef7e97a13d57d2f57a34118054a
Change-Id-Short: wsxvklkslqsp