### PR TITLE
fix: being able to disable the plugin

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -1,7 +1,9 @@
--- Kobo Plugin Metadata
+local _ = require("gettext")
+
 return {
     id = "kobo.koplugin",
-    name = "Kobo",
+    name = "kobo",
+    fullname = _("Kobo"),
     description = [[Browse and open unencrypted kepub books from Kobo Nickel library.
 This plugin creates a virtual library from books synced via Kobo's Nickel OS,
 allowing you to read them directly in KOReader without file extension workarounds.]],


### PR DESCRIPTION
Due to a miss match in the plugin folder name and name field in _meta.lua, it is not possible to disable the plugin from the plugin management settings.

Change-Id: 27344112fbb791ca8fbbb0bb92e74347
Change-Id-Short: xswvvyyxkoos
Relates-To: https://github.com/koreader/koreader/issues/14756