### PR TITLE
fix(BT key bindings): support registered actions after init

### DIFF
--- a/spec/bluetooth_action_prefixing_integration_spec.lua
+++ b/spec/bluetooth_action_prefixing_integration_spec.lua
@@ -4,13 +4,15 @@
 
 describe("Bluetooth Action ID Prefixing Integration", function()
     local BluetoothKeyBindings
+    local available_actions_module
     local AvailableActions
     local instance
 
     setup(function()
         require("spec/helper")
         BluetoothKeyBindings = require("src/bluetooth_keybindings")
-        AvailableActions = require("src/lib/bluetooth/available_actions")
+        available_actions_module = require("src/lib/bluetooth/available_actions")
+        AvailableActions = available_actions_module.get_all_actions()
     end)
 
     before_each(function()

--- a/spec/bluetooth_keybindings_spec.lua
+++ b/spec/bluetooth_keybindings_spec.lua
@@ -5,21 +5,15 @@ describe("BluetoothKeyBindings", function()
     local BluetoothKeyBindings
     local mock_settings
     local instance
+    local available_actions_module
     local AVAILABLE_ACTIONS
 
     setup(function()
         require("spec/helper")
         BluetoothKeyBindings = require("src/bluetooth_keybindings")
-        -- Access the module-level AVAILABLE_ACTIONS constant
-        -- We'll get it from a test instance
-        local temp = BluetoothKeyBindings:new({})
-        AVAILABLE_ACTIONS = temp.AVAILABLE_ACTIONS
-            or {
-                { id = "next_page", title = "Next Page", event = "GotoViewRel", args = 1 },
-                { id = "prev_page", title = "Previous Page", event = "GotoViewRel", args = -1 },
-                { id = "next_chapter", title = "Next Chapter", event = "GotoNextChapter" },
-                { id = "prev_chapter", title = "Previous Chapter", event = "GotoPrevChapter" },
-            }
+        -- Access the available actions module
+        available_actions_module = require("src/lib/bluetooth/available_actions")
+        AVAILABLE_ACTIONS = available_actions_module.get_all_actions()
     end)
 
     before_each(function()
@@ -51,12 +45,14 @@ describe("BluetoothKeyBindings", function()
             local has_next_page = false
             local has_prev_page = false
 
-            for _, action in ipairs(AVAILABLE_ACTIONS) do
-                if action.id == "next_page" then
-                    has_next_page = true
-                end
-                if action.id == "prev_page" then
-                    has_prev_page = true
+            for _, category in ipairs(AVAILABLE_ACTIONS) do
+                for _, action in ipairs(category.actions) do
+                    if action.id == "next_page" then
+                        has_next_page = true
+                    end
+                    if action.id == "prev_page" then
+                        has_prev_page = true
+                    end
                 end
             end
 
@@ -396,11 +392,13 @@ describe("BluetoothKeyBindings", function()
 
     describe("action definitions", function()
         it("should have valid event names for all actions", function()
-            for _, action in ipairs(AVAILABLE_ACTIONS) do
-                assert.is_string(action.id)
-                assert.is_string(action.title)
-                assert.is_string(action.event)
-                -- args can be nil or any value
+            for _, category in ipairs(AVAILABLE_ACTIONS) do
+                for _, action in ipairs(category.actions) do
+                    assert.is_string(action.id)
+                    assert.is_string(action.title)
+                    assert.is_string(action.event)
+                    -- args can be nil or any value
+                end
             end
         end)
 

--- a/src/lib/bluetooth/available_actions.lua
+++ b/src/lib/bluetooth/available_actions.lua
@@ -3,9 +3,16 @@
 ---
 --- This file dynamically loads all Dispatcher actions at runtime.
 --- Falls back to a minimal static list if dynamic extraction is unavailable.
+---
+--- The module patches Dispatcher.registerAction to capture actions registered
+--- after initial load, ensuring the action list stays synchronized with all
+--- plugins that register Dispatcher actions.
 
 local _ = require("gettext")
 local dispatcher_helper = require("src/lib/bluetooth/dispatcher_helper")
+local logger = require("logger")
+
+local M = {}
 
 ---
 --- Category definitions for organizing actions.
@@ -21,24 +28,211 @@ local CATEGORIES = {
 }
 
 ---
---- Get all available actions for Bluetooth key bindings.
---- Attempts to dynamically extract from Dispatcher.
---- Falls back to a minimal static list if extraction fails.
+--- Internal state for live action list and dispatcher patching.
 ---
---- @return table Categorized action definitions with structure:
----         {
----           {category = "General", actions = {...}},
----           {category = "Device", actions = {...}},
----           ...
----         }
----         Each action has fields:
----         - id: unique identifier
----         - title: display name (translated)
----         - event: KOReader event name
----         - args: optional arguments
----         - description: user-friendly description
----         - dispatcher_id: internal action key from Dispatcher (if dynamic)
+local _live_actions_list = nil
+local _is_dispatcher_patched = false
+local _original_registerAction = nil
+local _action_registered_callbacks = {}
+
 ---
+--- Trigger all registered callbacks when a new action is added to live list.
+--- @param action_id string The dispatcher action ID
+--- @param action table The fully-formed action from live_actions_list
+--- @param category string The category title
+local function _trigger_action_registered_callbacks(action_id, action, category)
+    for _, callback in ipairs(_action_registered_callbacks) do
+        logger.dbg("available_actions: Triggering action registered callback for action:", action_id)
+
+        local ok, err = pcall(callback, action_id, action, category)
+        if not ok then
+            logger.warn("available_actions: Callback error:", err)
+        end
+    end
+end
+
+---
+--- Build an action object from a definition.
+--- Consolidates common action construction logic used by both
+--- initial list building and live list updates.
+--- @param def table The action definition
+--- @param action_id_field string|nil Field name for action ID (defaults to "dispatcher_id")
+--- @param action_id string|nil Override action ID (used if provided)
+--- @return table|nil Action object or nil if invalid
+local function _build_action_from_def(def, action_id_field, action_id)
+    if not def or not def.event then
+        return nil
+    end
+
+    local id = action_id or def[action_id_field or "dispatcher_id"] or ""
+
+    local action = {
+        id = id,
+        title = def.title or "Unknown",
+        event = def.event,
+        description = def.title or "",
+    }
+
+    if def.args ~= nil then
+        action.args = def.args
+    end
+
+    if def.arg ~= nil then
+        if def.args ~= nil then
+            logger.warn(
+                "available_actions: Both 'args' and 'arg' defined for action:",
+                action.id,
+                "- 'arg' takes priority"
+            )
+        end
+
+        action.args = def.arg
+    end
+
+    if def.args_func then
+        action.args_func = def.args_func
+    end
+
+    if def.toggle then
+        action.toggle = def.toggle
+    end
+
+    if def.category then
+        action.category = def.category
+    end
+
+    return action
+end
+
+---
+--- Set category flags on an action from a definition.
+--- Copies all category boolean flags from definition to action.
+--- @param action table The action to update
+--- @param def table The definition with category flags
+local function _set_action_category_flags(action, def)
+    action.general = def.general or false
+    action.device = def.device or false
+    action.screen = def.screen or false
+    action.filemanager = def.filemanager or false
+    action.reader = def.reader or false
+    action.rolling = def.rolling or false
+    action.paging = def.paging or false
+end
+
+---
+--- Add a newly registered action to the live actions list.
+--- This is called by the patched Dispatcher.registerAction.
+--- @param action_id string The action ID
+--- @param def table The action definition from registerAction
+local function _add_new_action_to_live_list(action_id, def)
+    if not _live_actions_list then
+        return
+    end
+
+    local action = _build_action_from_def(def, nil, action_id)
+
+    if not action then
+        logger.dbg("available_actions: Skipping action without event:", action_id)
+
+        return
+    end
+
+    _set_action_category_flags(action, def)
+
+    local categories_by_title = {}
+    for _, category_data in ipairs(_live_actions_list) do
+        categories_by_title[category_data.category] = category_data
+    end
+
+    local added_to_categories = {}
+
+    for _, cat_def in ipairs(CATEGORIES) do
+        if action[cat_def.key] then
+            local category_data = categories_by_title[cat_def.title]
+
+            if not category_data then
+                category_data = {
+                    category = cat_def.title,
+                    actions = {},
+                }
+                table.insert(_live_actions_list, category_data)
+                categories_by_title[cat_def.title] = category_data
+                logger.dbg("available_actions: Created new category:", cat_def.title)
+            end
+
+            local action_exists = false
+            for i, existing_action in ipairs(category_data.actions) do
+                if existing_action.id == action_id then
+                    category_data.actions[i] = action
+                    action_exists = true
+                    logger.dbg("available_actions: Updated existing action:", action_id, "in", category_data.category)
+                    break
+                end
+            end
+
+            if not action_exists then
+                table.insert(category_data.actions, action)
+            end
+
+            table.sort(category_data.actions, function(a, b)
+                return (a.title or "") < (b.title or "")
+            end)
+
+            _trigger_action_registered_callbacks(action_id, action, cat_def.title)
+
+            table.insert(added_to_categories, cat_def.title)
+        end
+    end
+
+    if #added_to_categories > 0 then
+        logger.dbg(
+            "available_actions: Added action:",
+            action_id,
+            "to categories:",
+            table.concat(added_to_categories, ", ")
+        )
+    else
+        logger.dbg("available_actions: Action", action_id, "not added to any category")
+    end
+end
+
+---
+--- Patch Dispatcher.registerAction to capture future action registrations.
+--- This is called once on first get_all_actions() call.
+local function _patch_dispatcher()
+    if _is_dispatcher_patched then
+        return
+    end
+
+    local ok, Dispatcher = pcall(require, "dispatcher")
+
+    if not ok or not Dispatcher then
+        logger.dbg("available_actions: Cannot patch Dispatcher - module not available")
+
+        return
+    end
+
+    if type(Dispatcher.registerAction) ~= "function" then
+        logger.dbg("available_actions: Cannot patch Dispatcher - registerAction is not a function")
+
+        return
+    end
+
+    _original_registerAction = Dispatcher.registerAction
+
+    Dispatcher.registerAction = function(self, action_id, action_def)
+        logger.dbg("available_actions: Intercepted Dispatcher.registerAction for action:", action_id)
+
+        local result = _original_registerAction(self, action_id, action_def)
+
+        _add_new_action_to_live_list(action_id, action_def)
+
+        return result
+    end
+
+    _is_dispatcher_patched = true
+    logger.info("available_actions: Successfully patched Dispatcher.registerAction")
+end
 
 ---
 --- Essential navigation actions that should always be available,
@@ -251,7 +445,10 @@ local function _organize_static_actions()
     return _finalize_categories(categories)
 end
 
-local function get_all_actions()
+---
+--- Build the initial actions list from Dispatcher.
+--- @return table Array of category groups with sorted actions
+local function _build_initial_actions_list()
     local ordered_actions = dispatcher_helper.get_dispatcher_actions_ordered()
 
     if not ordered_actions then
@@ -263,58 +460,12 @@ local function get_all_actions()
 
     for _, item in ipairs(ordered_actions) do
         if type(item) == "table" and item.event then
-            local action = {
-                id = item.dispatcher_id or "",
-                title = item.title or "Unknown",
-                event = item.event,
-                description = item.title or "",
-            }
+            local action = _build_action_from_def(item, "dispatcher_id")
 
-            if item.args ~= nil then
-                action.args = item.args
+            if action then
+                _set_action_category_flags(action, item)
+                actions_by_id[action.id] = action
             end
-
-            if item.args_func then
-                action.args_func = item.args_func
-            end
-
-            if item.toggle then
-                action.toggle = item.toggle
-            end
-
-            if item.category then
-                action.category = item.category
-            end
-
-            if item.general then
-                action.general = true
-            end
-
-            if item.device then
-                action.device = true
-            end
-
-            if item.screen then
-                action.screen = true
-            end
-
-            if item.filemanager then
-                action.filemanager = true
-            end
-
-            if item.reader then
-                action.reader = true
-            end
-
-            if item.rolling then
-                action.rolling = true
-            end
-
-            if item.paging then
-                action.paging = true
-            end
-
-            actions_by_id[action.id] = action
         end
     end
 
@@ -333,4 +484,68 @@ local function get_all_actions()
     return _finalize_categories(categories)
 end
 
-return get_all_actions()
+---
+--- Get all available actions for Bluetooth key bindings.
+--- Attempts to dynamically extract from Dispatcher.
+--- Falls back to a minimal static list if extraction fails.
+---
+--- On first call, this function:
+--- 1. Extracts currently registered Dispatcher actions
+--- 2. Patches Dispatcher.registerAction to capture future registrations
+--- 3. Returns the categorized action list
+---
+--- Subsequent calls return the cached (and potentially updated) list.
+---
+--- WARNING: Do not modify the returned value. The table is cached and shared
+---          across all callers. Modifications will affect all consumers of this
+---          data and may cause unexpected behavior.
+---
+--- @return table Categorized action definitions with structure:
+---         {
+---           {category = "General", actions = {...}},
+---           {category = "Device", actions = {...}},
+---           ...
+---         }
+---         Each action has fields:
+---         - id: unique identifier
+---         - title: display name (translated)
+---         - event: KOReader event name
+---         - args: optional arguments
+---         - description: user-friendly description
+function M.get_all_actions()
+    if not _live_actions_list then
+        logger.dbg("available_actions: Building initial actions list")
+        _live_actions_list = _build_initial_actions_list()
+        _patch_dispatcher()
+    end
+
+    return _live_actions_list
+end
+
+---
+--- Gets the category title for an action definition.
+--- Returns the first matching category based on flags.
+--- @param def table Action definition with category flags
+--- @return string|nil Category title or nil if no category matches
+function M.get_category_from_def(def)
+    for _, cat_def in ipairs(CATEGORIES) do
+        if def[cat_def.key] == true then
+            return cat_def.title
+        end
+    end
+
+    return nil
+end
+
+---
+--- Register a callback to be called when a new action is registered.
+--- Callback signature: function(action_id, action, category)
+--- @param callback function Function to call when action is registered
+function M.register_on_action_registered(callback)
+    if type(callback) == "function" then
+        table.insert(_action_registered_callbacks, callback)
+        logger.dbg("available_actions: Registered callback for action registration")
+    end
+end
+
+return M


### PR DESCRIPTION
Refactor Bluetooth action handling to support dynamic registration of actions after initialization. The available_actions module now patches Dispatcher.registerAction to capture new actions at runtime, ensuring the action list stays synchronized with all plugins.

- Patch Dispatcher.registerAction to track new actions after load
- Add callback registration for action additions in available_actions
- Update BluetoothKeyBindings to use new available_actions API
- Lazily build and update action lookup map for O(1) retrieval
- Update tests to use get_all_actions and new structure

Change-Id: 60bad2cef9a286e0af9a492dcbfb16d4
Change-Id-Short: tzopmxnlkqpx
Fixes: #138