### PR TITLE
fix(virtual_library): override default docsetting

### DIFF
--- a/docs/dev/database/koreader/01-docsettings.md
+++ b/docs/dev/database/koreader/01-docsettings.md
@@ -9,11 +9,46 @@ serialized to disk.
 
 ### File Location
 
-For a book at `/mnt/onboard/.kobo/kepub/book.epub`, the sidecar is at:
+KOReader supports three location modes for storing sidecar files, configured via the "Document
+metadata folder" setting:
+
+1. **Document folder ("doc")**: Sidecar stored next to the book file
+2. **docsettings folder ("dir")**: Sidecar stored in a central docsettings directory
+3. **Hash folder ("hash")**: Sidecar stored in a hashed subdirectory structure
+
+For books opened through the virtual library, the plugin automatically overrides the "doc" location
+to use "dir" location instead.
+
+#### Example Locations
+
+**Standard EPUB** with "doc" location:
 
 ```
-/mnt/onboard/.kobo/kepub/book.sdr/metadata.epub.lua
+/mnt/onboard/Books/book.epub
+/mnt/onboard/Books/book.sdr/metadata.epub.lua
 ```
+
+**Virtual library book** with "doc" location (automatically overridden to "dir"):
+
+```
+/mnt/onboard/.kobo/kepub/ABC123
+/mnt/onboard/.adds/koreader/docsettings/mnt/onboard/.kobo/kepub/ABC123.sdr/metadata.kepub.epub.lua
+```
+
+#### Virtual Library Books Location Override
+
+The plugin overrides "doc" location to "dir" for virtual library books to prevent data loss. This is
+necessary because:
+
+- Kobo's system may delete unrecognized files in the virtual library directory during maintenance
+  operations
+- Storing sidecar files alongside virtual library books could result in loss of reading progress and
+  bookmarks
+- The "dir" location stores sidecars in KOReader's dedicated folder, which Kobo's system does not
+  touch
+
+**Note**: The "hash" location is respected and not overridden, as it also stores files outside the
+virtual library directory.
 
 ### Key Fields
 

--- a/docs/features/virtual-library.md
+++ b/docs/features/virtual-library.md
@@ -63,6 +63,22 @@ Each virtual book entry includes:
 - **Cover**: Extracted from Kobo's cover cache
 - **Series**: Extracted from Kobo's database
 
+## Document Metadata Location
+
+For kepub books opened through the virtual library, KOReader stores metadata in a specific location
+to prevent data loss:
+
+- **Automatic Override**: When you open a kepub book, the plugin automatically overrides the "doc"
+  metadata location setting to use "dir" location instead
+- **Why**: Kobo's system may delete files stored alongside kepub files in the kepub directory,
+  causing potential data loss
+- **Hash Location**: The "hash" metadata location setting is respected and not overridden
+- **Dir Location**: The "dir" metadata location setting works normally
+
+**What this means for you**: If you have KOReader's "Document metadata folder" setting set to
+"Document folder", kepub books will automatically store their metadata in the "docsettings" folder
+instead, protecting your reading progress and bookmarks from being accidentally deleted by Kobo.
+
 ## Troubleshooting Virtual Library
 
 ### Missing Books

--- a/spec/docsettings_ext_spec.lua
+++ b/spec/docsettings_ext_spec.lua
@@ -1,0 +1,110 @@
+describe("DocSettingsExt", function()
+    local DocSettingsExt
+
+    setup(function()
+        require("spec/helper")
+        DocSettingsExt = require("src/docsettings_ext")
+    end)
+
+    describe("location override for kepub files", function()
+        local mock_virtual_library
+        local mock_docsettings
+
+        before_each(function()
+            mock_virtual_library = {
+                isActive = function()
+                    return true
+                end,
+                isVirtualPath = function(self, path)
+                    if type(path) ~= "string" then
+                        return false
+                    end
+                    return path:match("^KOBO_VIRTUAL://") ~= nil
+                end,
+                getRealPath = function(self, path)
+                    if path == "KOBO_VIRTUAL://shelf1/book.kepub.epub" then
+                        return "/mnt/onboard/.kobo/kepub/ABC123"
+                    end
+                    return nil
+                end,
+                getVirtualPath = function(self, path)
+                    if path == "/mnt/onboard/.kobo/kepub/ABC123" then
+                        return "KOBO_VIRTUAL://shelf1/book.kepub.epub"
+                    end
+                    return nil
+                end,
+                real_to_virtual = {
+                    ["/mnt/onboard/.kobo/kepub/ABC123"] = "KOBO_VIRTUAL://shelf1/book.kepub.epub",
+                },
+            }
+
+            -- Mock DocSettings
+            mock_docsettings = {
+                getSidecarDir = function(self, doc_path, force_location)
+                    return doc_path .. ".sdr"
+                end,
+                getSidecarFilename = function(doc_path)
+                    return "metadata." .. doc_path:match("([^/]+)$") .. ".lua"
+                end,
+                getHistoryPath = function(self, doc_path)
+                    return "/mnt/onboard/.kobo/koreader/history/" .. doc_path:match("([^/]+)$") .. ".lua"
+                end,
+            }
+
+            -- Reset G_reader_settings to empty state
+            _G.G_reader_settings._settings = {}
+
+            -- Initialize extension
+            DocSettingsExt:init(mock_virtual_library)
+            DocSettingsExt:apply(mock_docsettings)
+        end)
+
+        after_each(function()
+            DocSettingsExt:unapply(mock_docsettings)
+            _G.G_reader_settings._settings = {}
+        end)
+
+        it("should override 'doc' location to 'dir' for kepub files", function()
+            _G.G_reader_settings._settings.document_metadata_folder = "doc"
+
+            local result = mock_docsettings:getSidecarDir("KOBO_VIRTUAL://shelf1/book.kepub.epub")
+
+            assert.equals("/mnt/onboard/.kobo/koreader/docsettings/mnt/onboard/.kobo/kepub/ABC123.sdr", result)
+        end)
+
+        it("should respect 'hash' location for kepub files", function()
+            _G.G_reader_settings._settings.document_metadata_folder = "hash"
+
+            local result = mock_docsettings:getSidecarDir("KOBO_VIRTUAL://shelf1/book.kepub.epub")
+
+            -- Result should be hash-based path, not dir-based
+            assert.is_not.equals("/mnt/onboard/.kobo/koreader/docsettings/mnt/onboard/.kobo/kepub/ABC123.sdr", result)
+            assert.is_truthy(result:match("%.sdr$"))
+        end)
+
+        it("should respect 'dir' location for kepub files", function()
+            _G.G_reader_settings._settings.document_metadata_folder = "dir"
+
+            local result = mock_docsettings:getSidecarDir("KOBO_VIRTUAL://shelf1/book.kepub.epub")
+
+            assert.equals("/mnt/onboard/.kobo/koreader/docsettings/mnt/onboard/.kobo/kepub/ABC123.sdr", result)
+        end)
+
+        it("should override 'doc' to 'dir' even when force_location is 'doc'", function()
+            _G.G_reader_settings._settings.document_metadata_folder = "hash"
+
+            local result = mock_docsettings:getSidecarDir("KOBO_VIRTUAL://shelf1/book.kepub.epub", "doc")
+
+            assert.equals("/mnt/onboard/.kobo/koreader/docsettings/mnt/onboard/.kobo/kepub/ABC123.sdr", result)
+        end)
+
+        it("should not override for non-kepub files with 'doc' location", function()
+            _G.G_reader_settings._settings.document_metadata_folder = "doc"
+
+            local result = mock_docsettings:getSidecarDir("/mnt/onboard/Books/regular.epub")
+
+            -- Should use original method, which returns path + .sdr
+            assert.equals("/mnt/onboard/Books/regular.epub.sdr", result)
+        end)
+    end)
+end)

--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -126,6 +126,20 @@ if not package.preload["logger"] then
     end
 end
 
+-- Mock datastorage module
+if not package.preload["datastorage"] then
+    package.preload["datastorage"] = function()
+        return {
+            getDocSettingsDir = function()
+                return "/mnt/onboard/.kobo/koreader/docsettings"
+            end,
+            getDocSettingsHashDir = function()
+                return "/mnt/onboard/.kobo/koreader/hash"
+            end,
+        }
+    end
+end
+
 -- Mock G_reader_settings global
 if not _G.G_reader_settings then
     _G.G_reader_settings = {
@@ -210,6 +224,15 @@ if not package.preload["util"] then
 
         function util.getFriendlySize(size)
             return tostring(size) .. " B"
+        end
+
+        function util.partialMD5(filepath)
+            if not filepath then
+                return nil
+            end
+            -- Return a mock MD5 hash for testing
+            local hash = "a1b2c3d4e5f6"
+            return hash
         end
 
         return util

--- a/src/docsettings_ext.lua
+++ b/src/docsettings_ext.lua
@@ -68,6 +68,13 @@ end
 
 ---
 --- Builds sidecar directory path based on user's preferred location.
+--- Overrides 'doc' location to 'dir' for kepub files to prevent deletion by Kobo.
+---
+--- Kobo's system may delete unrecognized files in the kepub directory during
+--- maintenance operations, which would cause data loss if KOReader stores sidecars
+--- there using the 'doc' location. The 'dir' location stores sidecars in KOReader's
+--- dedicated folder, which Kobo's system does not touch.
+---
 --- @param real_path string: Real file path.
 --- @param force_location string|nil: Forced location override.
 --- @return string: Sidecar directory path with .sdr extension.
@@ -87,8 +94,10 @@ local function buildKepubSidecarPath(real_path, force_location)
         return sidecar_path .. ".sdr"
     end
 
-    sidecar_path = real_path
-    logger.dbg("KoboPlugin: Using 'doc' location:", sidecar_path)
+    logger.warn(
+        "KoboPlugin: 'doc' location not supported for kepub files, overriding to 'dir' to prevent file deletion"
+    )
+    sidecar_path = buildDirLocationPath(real_path)
 
     return sidecar_path .. ".sdr"
 end


### PR DESCRIPTION
Ensure that when opening books from the virtual library, the "doc" sidecar location is automatically overridden to "dir" to prevent loss of metadata due to Kobo system deleting of foreign files.

- Override "doc" location to "dir" for virtual library books
- Prevents accidental deletion of reading progress and bookmarks
- "hash" location is respected and not overridden

Change-Id: 350b1b543d6653e377f3b118e9359a66
Change-Id-Short: wuzoyouvwmtt
Fixes: #129