### PR TITLE
fix(virtual library): remove refresh on device wakeup

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -545,14 +545,7 @@ function KoboPlugin:onCloseDocument() end
 
 ---
 --- Called when device resumes from suspend.
---- Refreshes virtual library to pick up any changes made in Kobo Nickel.
-function KoboPlugin:onResume()
-    if not self.virtual_library or not self.virtual_library:isActive() then
-        return
-    end
-
-    self.virtual_library:refresh()
-end
+function KoboPlugin:onResume() end
 
 ---
 --- Registers dispatcher actions for connecting to paired Bluetooth devices.


### PR DESCRIPTION
The plugin was refreshing the virtual library when the device wakes from suspend, but this is unnecessary. Device suspend/wake does not alter the library state, and the virtual library feature can be disabled entirely. Removes the unused onResume() implementation that performed this refresh.

- Remove onResume() method from KoboPlugin
- Remove virtual library refresh on device wake

perf: resume from suspend no longer refreshes virtual library this means that resuming from suspend is faster

Change-Id: c6d8880302ef8e9697afcdd5fb7d3ef8
Change-Id-Short: ntmrrrzwzxlk
Fixes: #161

<!--
BEGIN_COMMIT_OVERRIDE
fix(virtual library): remove refresh on device wakeup (#162)

The plugin was refreshing the virtual library when the device wakes from suspend, but this is unnecessary. Device suspend/wake does not alter the library state, and the virtual library feature can be disabled entirely. Removes the unused onResume() implementation that performed this refresh.

- Remove onResume() method from KoboPlugin
- Remove virtual library refresh on device wake

Fixes: #161

perf: resume from suspend no longer refreshes virtual library this means that resuming from suspend is faster (#162)

Change-Id: c6d8880302ef8e9697afcdd5fb7d3ef8
Change-Id-Short: ntmrrrzwzxlk
Fixes: #161
END_COMMIT_OVERRIDE
-->