### PR TITLE
refactor(virtual library): use database for DRM detection

### DIFF
--- a/docs/dev/virtual-library/drm-detection.md
+++ b/docs/dev/virtual-library/drm-detection.md
@@ -4,29 +4,72 @@ The virtual library needs to identify which books are encrypted with DRM to prev
 attempting to open books that KOReader cannot read. This is critical for providing a good user
 experience and avoiding error messages when browsing the library.
 
-## Why Content-Based Detection?
+## Database-Only Detection
 
-### Historical Approach: rights.xml
+The plugin uses a simple and fast database lookup to determine if a book is DRM-encrypted.
 
-Earlier approaches to DRM detection relied on checking for the presence of a `rights.xml` file in
-the EPUB/KEPUB archive. This file is part of Adobe's ADEPT DRM system and typically contains
-metadata about the DRM protection.
+### How It Works
 
-**Problems with this approach:**
+Query the `content_keys` table in the native Kobo database:
 
-1. **False Positives**: Some DRM-free books may contain `rights.xml` files that are simply empty or
-   contain non-restrictive metadata
-2. **Incomplete**: Not all DRM systems use `rights.xml` - other protection schemes exist
-3. **Unreliable**: The presence of the file doesn't guarantee the content is actually encrypted
+```sql
+SELECT 1 FROM content_keys WHERE volumeId = ? LIMIT 1
+```
 
-### Current Approach: Content Examination
+**Detection logic:**
 
-The plugin now examines the actual content files within the EPUB/KEPUB archive to determine if they
-are readable. This provides a more reliable detection mechanism that works across different DRM
-implementations.
+- **Keys exist** → Book is KDRM-encrypted (Kobo-purchased)
+- **No keys** → Book is not encrypted (sideloaded DRM-free)
+
+### Why This Works
+
+The `content_keys` table is populated by Kobo for **all KDRM-protected books on disk**. This table
+stores the encrypted content keys needed to decrypt individual files within the EPUB/KEPUB archive.
+
+**Key characteristics:**
+
+1. **Present for all encrypted books**: Kobo populates this table when syncing or downloading books
+2. **Absent for sideloaded books**: Books transferred via USB don't have KDRM protection
+3. **Indexed query**: Fast O(1) lookup using the covering index on `volumeId`
+4. **Authoritative**: This is the same table Kobo uses internally for decryption
+
+## Historical Approaches (Deprecated)
+
+### Content Examination
+
+Earlier versions examined actual file content by:
+
+1. Opening the ZIP archive
+2. Finding XHTML/HTML files
+3. Extracting to memory
+4. Checking for readable XML/HTML markers
+
+**Why it was removed:**
+
+- Significantly slower (requires file I/O + decompression)
+- Unnecessary complexity
+- Database lookup is both faster and more reliable
+
+### rights.xml Check
+
+Even earlier approaches checked for a `rights.xml` file in the archive.
+
+**Why it was removed:**
+
+1. **False positives**: DRM-free books may contain empty `rights.xml` files
+2. **Incomplete**: Doesn't reliably indicate KDRM encryption
+3. **Unreliable**: File presence doesn't guarantee content is encrypted
+
+## Implementation
+
+See `src/metadata_parser.lua:isBookEncrypted()` for the implementation. The method performs a single
+database query and returns the result.
 
 ---
 
 References:
 
-- https://github.com/OGKevin/kobo.koplugin/issues/119
+- [Issue #119: DRM detection improvements](https://github.com/OGKevin/kobo.koplugin/issues/119)
+- [Issue #73: DRM removal investigation](https://github.com/OGKevin/kobo.koplugin/issues/73)
+- [DRM Removal Investigation](../investigations/drm-removal.md)
+- [Database Schema: content_keys table](../database/kobo/01-schema.md)


### PR DESCRIPTION
Switch DRM detection from content examination to content_keys database lookup. This approach is faster (O(1) lookup), more reliable, and aligns with Kobo's internal implementation.

- Replace archive inspection with content_keys table query
- Simplify test cases to verify database-based logic
- Update documentation to reflect new implementation
- Improve logging and error handling

Change-Id: 9cc958103fea27f5b7e02306b58a6135
Change-Id-Short: qnnquryzwklp
Relates-To: #73

perf: optimize DRM detection using database lookup
Relates-To: #73