### PR TITLE
fix: pass mimetype args to hasProvider

### DIFF
--- a/src/docsettings_ext.lua
+++ b/src/docsettings_ext.lua
@@ -160,6 +160,10 @@ function DocSettingsExt:apply(DocSettings)
 
     self.original_methods.getSidecarFilename = DocSettings.getSidecarFilename
     DocSettings.getSidecarFilename = function(doc_path)
+        if doc_path and doc_path:match("^dummy%.") then
+            return self.original_methods.getSidecarFilename(doc_path)
+        end
+
         local actual_path = doc_path
 
         if self.virtual_library:isVirtualPath(doc_path) then

--- a/src/document_ext.lua
+++ b/src/document_ext.lua
@@ -78,9 +78,9 @@ function DocumentExt:apply(DocumentRegistry)
     logger.info("KoboPlugin: Applying DocumentRegistry monkey patches for Kobo kepub files")
 
     self.original_methods.hasProvider = DocumentRegistry.hasProvider
-    DocumentRegistry.hasProvider = function(dr_self, file)
+    DocumentRegistry.hasProvider = function(dr_self, file, mimetype, include_aux)
         if not self.virtual_library:isVirtualPath(file) then
-            return self.original_methods.hasProvider(dr_self, file)
+            return self.original_methods.hasProvider(dr_self, file, mimetype, include_aux)
         end
 
         return true


### PR DESCRIPTION
Fix DocumentRegistry.hasProvider to forward mimetype and
include_aux arguments to the original method. Add guard to
skip virtual path processing for dummy files in sidecar path
resolution.

- Forward mimetype and include_aux args in hasProvider wrapper
- Skip virtual library processing for dummy file paths
- Preserve backward compatibility with original methods

Change-Id: ca64b0ce25fe6496d044af017c700cd1
Change-Id-Short: nptvoznlxukl
Fixes: #124
Fixes: #48
