### PR TITLE
feat: add virtual library cover path configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mermaid.min.js
 
 .lua
 .luarocks
+.tmp

--- a/docs/settings/virtual-library/index.md
+++ b/docs/settings/virtual-library/index.md
@@ -5,11 +5,31 @@
   sync-related menu items will be hidden. A restart is required for changes to take effect.
   (Default: enabled)
 
+- **Virtual library folder cover** - Select a custom cover image file for the virtual library
+  folder. Only available when the virtual library is enabled. This is used by the
+  [ProjectTitle](https://github.com/joshuacant/ProjectTitle) plugin to display a custom thumbnail
+  for the virtual library folder instead of falling back to an auto-generated cover. (Default: none)
+
 ## Details
 
 When the virtual library is enabled, the plugin exposes a virtual view of your Kobo device's library
 inside KOReader. This virtual view is populated from Kobo's metadata and lets you browse, search,
 and open titles backed by Kobo's database without switching to the native Kobo reader.
+
+## ProjectTitle Integration
+
+This plugin integrates with [ProjectTitle](https://github.com/joshuacant/ProjectTitle), a KOReader
+plugin that enhances folder cover display. When a cover image is configured via the **Virtual
+library folder cover** setting, the plugin passes the file path to ProjectTitle using the
+`pt_cover_path` field on the virtual folder entry. ProjectTitle then uses this explicit path to
+display the chosen image as the folder thumbnail instead of auto-detecting one.
+
+To use this feature:
+
+1. Install the [ProjectTitle](https://github.com/joshuacant/ProjectTitle) plugin in KOReader.
+2. Enable the virtual library in Kobo Library settings.
+3. Open **Kobo Library → Virtual library folder cover** and select an image file.
+4. ProjectTitle will display the selected image as the virtual library folder cover.
 
 ## Behavior
 

--- a/docs/settings/virtual-library/menu.md
+++ b/docs/settings/virtual-library/menu.md
@@ -10,6 +10,7 @@
 ```
 Kobo Library
 ├── Enable virtual library [Toggle]
+├── Virtual library folder cover [Action]
 ├── Sync reading state with Kobo [Toggle]
 ├── Sync settings [Submenu]
 │   ├── Enable automatic sync [Toggle]
@@ -45,6 +46,7 @@ Kobo Library
 | Menu Item                    | Type   | Default                    | Function                                                                                      |
 | ---------------------------- | ------ | -------------------------- | --------------------------------------------------------------------------------------------- |
 | Enable virtual library       | Toggle | On                         | Show/hide the Kobo Library folder in KOReader's file browser                                  |
+| Virtual library folder cover | Action | —                          | Select a custom cover image for the virtual library folder (used by ProjectTitle plugin)      |
 | Sync reading state with Kobo | Toggle | Off                        | Enable/disable synchronization of reading progress between KOReader and Kobo Nickel           |
 | Enable automatic sync        | Toggle | Off                        | Automatically sync when opening the virtual library (once per startup)                        |
 | Sync on startup              | Toggle | Off                        | Sync reading state when opening books from the virtual library                                |

--- a/src/virtual_library.lua
+++ b/src/virtual_library.lua
@@ -27,10 +27,18 @@ function VirtualLibrary:new(metadata_parser)
         virtual_to_real = {},
         real_to_virtual = {},
         book_id_to_virtual = {},
+        settings = nil,
     }
     setmetatable(o, self)
     self.__index = self
     return o
+end
+
+---
+--- Sets plugin settings for access to configuration options.
+--- @param settings table: Plugin settings table.
+function VirtualLibrary:setSettings(settings)
+    self.settings = settings
 end
 
 ---
@@ -231,12 +239,22 @@ end
 --- @param parent_path string: Path to the parent directory.
 --- @return table: Folder entry for the virtual library.
 function VirtualLibrary:createVirtualFolderEntry(parent_path)
-    return {
+    local entry = {
         text = self.VIRTUAL_LIBRARY_NAME .. "/",
         path = parent_path .. "/" .. self.VIRTUAL_LIBRARY_NAME,
         is_kobo_virtual_folder = true,
         bidi_wrap_func = BD.directory,
     }
+
+    if
+        self.settings
+        and self.settings.virtual_library_cover_path
+        and self.settings.virtual_library_cover_path ~= ""
+    then
+        entry.pt_cover_path = self.settings.virtual_library_cover_path
+    end
+
+    return entry
 end
 
 ---


### PR DESCRIPTION
<!--
BEGIN_COMMIT_OVERRIDE
feat(Virtual Library): add cover path configuration (#189)
Release-As: v0.4.1
Fixes: #185
END_COMMIT_OVERRIDE
-->

Add support for setting a custom cover image for the virtual library folder, used by ProjectTitle plugin for enhanced visual presentation.

- Add virtual_library_cover_path setting to plugin defaults
- Create setSettings method in VirtualLibrary for accessing plugin configuration
- Add createVirtualLibraryCoverMenuItem for file path selection UI with enabled_func check for virtual library setting
- Update createVirtualFolderEntry to include pt_cover_path when custom cover path is configured
- Update .gitignore to exclude .tmp directory

Change-Id: e673c652ea2c8f4cff78ee1b4e8248f4
Change-Id-Short: ltswntuxlpxn
Relates-To: https://github.com/joshuacant/ProjectTitle/issues/162