### PR TITLE
fix(Virtual Library): hide parent entry when lock_home_folder is enabled

### DIFF
--- a/spec/filechooser_ext_spec.lua
+++ b/spec/filechooser_ext_spec.lua
@@ -204,6 +204,54 @@ describe("FileChooserExt", function()
             assert.is_true(back_entry.is_go_up)
             assert.equals("/", back_entry.path)
         end)
+
+        it("should hide back entry when lock_home_folder is enabled and home_dir is virtual path", function()
+            G_reader_settings:saveSetting("home_dir", "KOBO_VIRTUAL://")
+            G_reader_settings:saveSetting("lock_home_folder", true)
+
+            FileChooserExt:apply(mock_file_chooser)
+            mock_file_chooser:showKoboVirtualLibrary()
+
+            local first_entry = mock_file_chooser.last_book_entries[1]
+            assert.is_not_nil(first_entry)
+            assert.is_nil(first_entry.is_go_up)
+        end)
+
+        it("should hide back entry when lock_home_folder is enabled and home_dir is virtual subpath", function()
+            G_reader_settings:saveSetting("home_dir", "KOBO_VIRTUAL://BOOKID123/somebook.epub")
+            G_reader_settings:saveSetting("lock_home_folder", true)
+
+            FileChooserExt:apply(mock_file_chooser)
+            mock_file_chooser:showKoboVirtualLibrary()
+
+            local first_entry = mock_file_chooser.last_book_entries[1]
+            assert.is_not_nil(first_entry)
+            assert.is_nil(first_entry.is_go_up)
+        end)
+
+        it("should show back entry when lock_home_folder is enabled but home_dir is not virtual", function()
+            G_reader_settings:saveSetting("home_dir", "/mnt/onboard/Books")
+            G_reader_settings:saveSetting("lock_home_folder", true)
+
+            FileChooserExt:apply(mock_file_chooser)
+            mock_file_chooser:showKoboVirtualLibrary()
+
+            local first_entry = mock_file_chooser.last_book_entries[1]
+            assert.is_not_nil(first_entry)
+            assert.is_true(first_entry.is_go_up)
+        end)
+
+        it("should show back entry when home_dir is virtual but lock_home_folder is not enabled", function()
+            G_reader_settings:saveSetting("home_dir", "KOBO_VIRTUAL://")
+            G_reader_settings:saveSetting("lock_home_folder", false)
+
+            FileChooserExt:apply(mock_file_chooser)
+            mock_file_chooser:showKoboVirtualLibrary()
+
+            local first_entry = mock_file_chooser.last_book_entries[1]
+            assert.is_not_nil(first_entry)
+            assert.is_true(first_entry.is_go_up)
+        end)
     end)
 
     describe("changeToPath interception", function()

--- a/src/filechooser_ext.lua
+++ b/src/filechooser_ext.lua
@@ -283,7 +283,20 @@ function FileChooserExt:apply(FileChooser)
             return
         end
 
-        table.insert(book_entries, 1, createBackEntry(self.virtual_library))
+        local virtual_prefix = self.virtual_library.VIRTUAL_PATH_PREFIX
+        local escaped_virtual_prefix = PatternUtils.escape(virtual_prefix)
+        local current_home_dir = G_reader_settings:readSetting("home_dir")
+        local home_is_virtual = current_home_dir
+            and (
+                current_home_dir == virtual_prefix
+                or current_home_dir == virtual_prefix .. "/"
+                or current_home_dir:match("^" .. escaped_virtual_prefix)
+            )
+        local locked_at_home = G_reader_settings:isTrue("lock_home_folder") and home_is_virtual
+
+        if not locked_at_home then
+            table.insert(book_entries, 1, createBackEntry(self.virtual_library))
+        end
         fc_self:switchItemTable(nil, book_entries, 1, nil, "Kobo Library")
     end
 end


### PR DESCRIPTION
## Summary

- Fixes the `^..` parent directory entry still appearing in the virtual library when `lock_home_folder` is enabled and `home_dir` is set to `KOBO_VIRTUAL://`
- Adds a check in `showKoboVirtualLibrary` that skips inserting the back entry when `lock_home_folder=true` and the home dir points to the virtual library, consistent with KOReader's native file browser behaviour

Closes #207

## Test plan

- [x] Verified manually on a Kobo Libra Colour with KOReader v2026.03 and kobo.koplugin v0.4.1
- [x] Unit tests added for all four cases: locked+virtual, locked+virtual-subpath, locked+non-virtual, unlocked+virtual