### PR TITLE
fix(progress sync): Set ReadStateSynced when updating read status

### DIFF
--- a/src/lib/kobo_state_writer.lua
+++ b/src/lib/kobo_state_writer.lua
@@ -208,7 +208,7 @@ end
 --- @return boolean: True if update succeeded.
 local function updateMainBookEntry(conn, book_id, percent_read, date_str, read_status, chapter_id_bookmarked)
     local stmt = conn:prepare(
-        "UPDATE content SET ___PercentRead = ?, DateLastRead = ?, ReadStatus = ?, ChapterIDBookmarked = ? WHERE ContentID = ? AND ContentType = 6"
+        "UPDATE content SET ___PercentRead = ?, DateLastRead = ?, ReadStatus = ?, ChapterIDBookmarked = ?, ReadStateSynced = 'false' WHERE ContentID = ? AND ContentType = 6"
     )
 
     if not stmt then


### PR DESCRIPTION
## Summary
During write operations to the content table in KoboReader.sqlite, we need to set the ReadStateSynced field to 'false' so Kobo will pick up the entry during the next sync operation with the upstream store.

Closes #211 

## Test Plan:

- [x] Tested on Kobo Libra Colour with KOReader v2026.03 and kobo.koplugin v0.4.1