### PR TITLE
fix(docsettings): guard against nil doc_path in resolveKepubRealPath

### DIFF
--- a/spec/docsettings_ext_spec.lua
+++ b/spec/docsettings_ext_spec.lua
@@ -46,6 +46,9 @@ describe("DocSettingsExt", function()
             -- Mock DocSettings
             mock_docsettings = {
                 getSidecarDir = function(self, doc_path, force_location)
+                    if not doc_path then
+                        return "ORIGINAL_FALLBACK"
+                    end
                     return doc_path .. ".sdr"
                 end,
                 getSidecarFilename = function(doc_path)
@@ -110,6 +113,14 @@ describe("DocSettingsExt", function()
 
             -- Should use original method, which returns path + .sdr
             assert.equals("/mnt/onboard/Books/regular.epub.sdr", result)
+        end)
+
+        it("should fall back to original when doc_path is nil (e.g. flush during resetDocumentSettings)", function()
+            _G.G_reader_settings._settings.document_metadata_folder = "doc"
+
+            local result = mock_docsettings:getSidecarDir(nil)
+
+            assert.equals("ORIGINAL_FALLBACK", result)
         end)
     end)
 end)

--- a/src/docsettings_ext.lua
+++ b/src/docsettings_ext.lua
@@ -37,6 +37,10 @@ end
 local function resolveKepubRealPath(doc_path, virtual_library)
     logger.dbg("KoboPlugin: resolveKepubRealPath called with", doc_path)
 
+    if not doc_path then
+        return nil
+    end
+
     if virtual_library:isVirtualPath(doc_path) then
         local real_path = virtual_library:getRealPath(doc_path)
 


### PR DESCRIPTION
## Summary
Fixes #217.

KOReader's `DocSettings:flush()` path (triggered by `resetDocumentSettings` from the reader menu's "Reset settings" confirm callback) calls the patched `getSidecarDir` without a path argument. The `nil` propagates into `resolveKepubRealPath`, passes the early `isVirtualPath` / `getVirtualPath` checks (which tolerate nil), and then crashes at `doc_path:match("/")` on line 55.

This patch adds an early `if not doc_path then return nil end` guard. The patched `getSidecarDir` at line ~188 already falls back to the original `DocSettings.getSidecarDir` whenever `resolveKepubRealPath` returns nil, which is the correct behavior here — the original handles missing paths.

## Test plan
- [x] Added unit test in `spec/docsettings_ext_spec.lua` asserting that the patched `getSidecarDir(nil)` reaches the original implementation rather than crashing in the kepub path.
- [x] Verified on-device (Kobo, KOReader v2026.03, kobo.koplugin 0.4.1): "Reset settings" on a book no longer crashes; reset behavior itself is unchanged.