### PR TITLE
fix(libra2): proper cold-start and teardown for Realtek RTL8723D

### DIFF
--- a/spec/lib/bluetooth/adapters/libra2_adapter_spec.lua
+++ b/spec/lib/bluetooth/adapters/libra2_adapter_spec.lua
@@ -72,22 +72,28 @@ describe("Libra2Adapter", function()
             assert.is_false(Libra2Adapter.turnOn())
         end)
 
-        it("should execute correct D-Bus commands", function()
+        it("should execute the chip-init + bluetoothd + Powered=true sequence", function()
             setMockExecuteResult(0)
             clearExecutedCommands()
 
             Libra2Adapter.turnOn()
 
             local commands = getExecutedCommands()
-            assert.are.equal(4, #commands)
-            assert.are.equal("/libexec/bluetooth/bluetoothd &", commands[1])
-            assert.are.equal("hciconfig hci0 down", commands[2])
-            assert.are.equal("hciconfig hci0 up", commands[3])
+            assert.are.equal(5, #commands)
+            -- 1. SDIO power rail driver
+            assert.is_truthy(commands[1]:match("insmod /drivers/mx6sll%-ntx/wifi/sdio_bt_pwr%.ko"))
+            -- 2. Realtek HCI UART attach
+            assert.is_truthy(commands[2]:match("rtk_hciattach"))
+            -- 3. bluetoothd
+            assert.are.equal("/libexec/bluetooth/bluetoothd &", commands[3])
+            -- 4. Wait loop until BlueZ registers hci0 on D-Bus
+            assert.is_truthy(commands[4]:match("Properties%.Get"))
+            -- 5. Set Powered=true
             assert.are.equal(
                 "dbus-send --system --print-reply --dest=org.bluez /org/bluez/hci0 "
                     .. "org.freedesktop.DBus.Properties.Set "
                     .. "string:org.bluez.Adapter1 string:Powered variant:boolean:true",
-                commands[4]
+                commands[5]
             )
         end)
     end)
@@ -103,7 +109,7 @@ describe("Libra2Adapter", function()
             assert.is_false(Libra2Adapter.turnOff())
         end)
 
-        it("should execute correct D-Bus commands", function()
+        it("should execute graceful Powered=false + full chip teardown", function()
             setMockExecuteResult(0)
             clearExecutedCommands()
 
@@ -117,7 +123,10 @@ describe("Libra2Adapter", function()
                     .. "string:org.bluez.Adapter1 string:Powered variant:boolean:false",
                 commands[1]
             )
-            assert.are.equal("killall bluetoothd", commands[2])
+            -- Compound teardown line: kill both daemons, wait for exit, rmmod the power rail.
+            assert.is_truthy(commands[2]:match("killall bluetoothd"))
+            assert.is_truthy(commands[2]:match("killall rtk_hciattach"))
+            assert.is_truthy(commands[2]:match("rmmod sdio_bt_pwr"))
         end)
     end)
 

--- a/spec/lib/bluetooth/dbus_adapter_spec.lua
+++ b/spec/lib/bluetooth/dbus_adapter_spec.lua
@@ -56,10 +56,10 @@ describe("DbusAdapter factory", function()
             local adapter = require("src/lib/bluetooth/dbus_adapter")
             adapter.turnOn()
 
-            -- Verify Libra 2 commands were executed (4 commands: bluetoothd, hciconfig down/up, dbus-send)
+            -- Verify Libra 2 commands ran (chip-init + bluetoothd + wait + Set=true).
             local commands = getExecutedCommands()
-            assert.are.equal(4, #commands)
-            assert.are.equal("/libexec/bluetooth/bluetoothd &", commands[1])
+            assert.are.equal(5, #commands)
+            assert.is_truthy(commands[1]:match("sdio_bt_pwr%.ko"))
         end)
 
         it("should return false for turnOn on unsupported devices", function()

--- a/src/lib/bluetooth/adapters/libra2_adapter.lua
+++ b/src/lib/bluetooth/adapters/libra2_adapter.lua
@@ -10,27 +10,38 @@ local logger = require("logger")
 local Libra2Adapter = {}
 
 ---
---- D-Bus commands for turning Bluetooth on.
---- Starts bluetoothd daemon, resets HCI interface, and powers on adapter.
---- @field table Array of command strings to execute in sequence.
+--- Bring the Realtek RTL8723D up and the BlueZ adapter to Powered=true.
+--- Chip-init (insmod, rtk_hciattach) is idempotent on warm starts. The
+--- poll waits for bluetoothd to enumerate hci0 on D-Bus before the Set,
+--- since BlueZ only exposes Adapter1 once it's noticed the new HCI device.
+--- @field table Array of shell commands run in sequence.
 Libra2Adapter.COMMANDS_ON = {
+    "grep -q '^sdio_bt_pwr ' /proc/modules || insmod /drivers/mx6sll-ntx/wifi/sdio_bt_pwr.ko",
+    "pgrep rtk_hciattach >/dev/null || /sbin/rtk_hciattach -s 115200 ttymxc1 rtk_h5 >/dev/null 2>&1",
     "/libexec/bluetooth/bluetoothd &",
-    "hciconfig hci0 down",
-    "hciconfig hci0 up",
+    "i=0; while [ $i -lt 50 ] && ! dbus-send --system --print-reply --dest=org.bluez /org/bluez/hci0 "
+        .. "org.freedesktop.DBus.Properties.Get string:org.bluez.Adapter1 string:Powered "
+        .. ">/dev/null 2>&1; do sleep 0.1; i=$((i+1)); done",
     "dbus-send --system --print-reply --dest=org.bluez /org/bluez/hci0 "
         .. "org.freedesktop.DBus.Properties.Set "
         .. "string:org.bluez.Adapter1 string:Powered variant:boolean:true",
 }
 
 ---
---- D-Bus commands for turning Bluetooth off.
---- Powers off adapter and stops bluetoothd daemon.
---- @field table Array of command strings to execute in sequence.
+--- Graceful Powered=false (so peers see a clean disconnect), then a full
+--- chip power-cycle: a soft power-off leaves rtk_hciattach holding the UART
+--- and the chip wedged against the next bringup. Wait for both daemons to
+--- exit before rmmod so the next ON doesn't race a dying bluetoothd for
+--- the org.bluez D-Bus name.
+--- @field table Array of shell commands run in sequence.
 Libra2Adapter.COMMANDS_OFF = {
     "dbus-send --system --print-reply --dest=org.bluez /org/bluez/hci0 "
         .. "org.freedesktop.DBus.Properties.Set "
         .. "string:org.bluez.Adapter1 string:Powered variant:boolean:false",
-    "killall bluetoothd",
+    "killall bluetoothd 2>/dev/null; killall rtk_hciattach 2>/dev/null; "
+        .. "i=0; while [ $i -lt 30 ] && (pgrep bluetoothd >/dev/null || pgrep rtk_hciattach >/dev/null); "
+        .. "do sleep 0.1; i=$((i+1)); done; "
+        .. "rmmod sdio_bt_pwr 2>/dev/null; true",
 }
 
 ---


### PR DESCRIPTION
Refs #181

The Libra 2 BT adapter assumed `hci0` already existed when the plugin
tried to bring it up, so on a cold boot the first `hciconfig` call
failed with "Can't get device info: No such device" and the whole
sequence aborted. This adds the missing chip-init steps before
`bluetoothd` runs, drops the `hciconfig down/up` reset that breaks
BlueZ's enumeration in the same race, and replaces the soft
`Powered=false` teardown with a full chip power-cycle so the next
bringup doesn't time out on the UART. Tested across cold boot and
repeated off→on cycles on a Libra 2.

Commit message has the full technical breakdown.

## Scope

Developed and tested on a **Kobo Libra 2** only — I can't verify behaviour
on MTK or other models, but this PR only touches `libra2_adapter.lua`
so other devices aren't affected.