### PR TITLE
feat(progress sync): include sideloaded books in reading state sync

### DIFF
--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -1317,6 +1317,25 @@ if not package.preload["lua-ljsqlite3/init"] then
                                     return nil -- Return nil when no keys (DONE)
                                 end
 
+                                -- Chapter lookup query (calculateChapterProgress): BookID/Title bound params.
+                                if
+                                    stmt_self._query:match("___FileOffset, ___FileSize, ___PercentRead")
+                                    and stmt_self._query:match("BookID = ")
+                                then
+                                    if stmt_self._chapter_lookup_done then
+                                        return nil
+                                    end
+                                    stmt_self._chapter_lookup_done = true
+
+                                    local book_id = stmt_self._bound_params[1] or "test_book_1"
+                                    if tostring(book_id):match("0N395DCCSFPF3") then
+                                        return nil
+                                    end
+
+                                    -- Row-major result (1-indexed), matching the real lua-ljsqlite3 step() API.
+                                    return { book_id .. "!!chapter_5.html", 50, 10, 0 }
+                                end
+
                                 if stmt_self._row_index < #mock_db_state.book_rows then
                                     stmt_self._row_index = stmt_self._row_index + 1
                                     return mock_db_state.book_rows[stmt_self._row_index]

--- a/spec/metadata_parser_spec.lua
+++ b/spec/metadata_parser_spec.lua
@@ -715,6 +715,96 @@ describe("MetadataParser", function()
         end)
     end)
 
+    describe("getSideloadedBooks", function()
+        local lfs, SQ3
+
+        before_each(function()
+            lfs = require("libs/libkoreader-lfs")
+            lfs._clearFileStates()
+            SQ3 = require("lua-ljsqlite3/init")
+            SQ3._clearMockState()
+        end)
+
+        it("should include only existing sideloaded books", function()
+            local parser = MetadataParser:new()
+            parser.db_path = "/tmp/.kobo/KoboReader.sqlite"
+            local kepub_path = parser:getKepubPath()
+
+            SQ3._setBookRows({
+                { "ACCESSIBLE", "Accessible Book", "Author 1", "", "", "", 50 },
+                { "file:///mnt/onboard/My%20Book.epub", "Sideloaded Book", "Author 2", "", "", "", 25 },
+                { "file:///mnt/onboard/Missing.epub", "Missing Sideload", "Author 3", "", "", "", 0 },
+            })
+
+            lfs._setFileState(kepub_path, {
+                exists = true,
+                attributes = { mode = "directory" },
+            })
+            lfs._setDirectoryContents(kepub_path, { ".", "..", "ACCESSIBLE" })
+
+            lfs._setFileState(kepub_path .. "/ACCESSIBLE", {
+                exists = true,
+                attributes = { mode = "file" },
+            })
+
+            lfs._setFileState("/mnt/onboard/My Book.epub", {
+                exists = true,
+                attributes = { mode = "file" },
+            })
+            lfs._setFileState("/mnt/onboard/Missing.epub", {
+                exists = false,
+                attributes = nil,
+            })
+
+            local sideloaded = parser:getSideloadedBooks()
+
+            assert.equals(1, #sideloaded)
+
+            local by_id = {}
+            for _, book in ipairs(sideloaded) do
+                by_id[book.id] = book
+            end
+
+            assert.is_not_nil(by_id["file:///mnt/onboard/My%20Book.epub"])
+            assert.is_nil(by_id["file:///mnt/onboard/Missing.epub"])
+            assert.is_true(by_id["file:///mnt/onboard/My%20Book.epub"].is_sideloaded)
+        end)
+
+        it("should keep accessible books limited to kobo files", function()
+            local parser = MetadataParser:new()
+            parser.db_path = "/tmp/.kobo/KoboReader.sqlite"
+            local kepub_path = parser:getKepubPath()
+
+            SQ3._setBookRows({
+                { "ACCESSIBLE", "Accessible Book", "Author", "", "", "", 50 },
+                { "file:///mnt/onboard/My%20Book.epub", "Sideloaded Book", "Author", "", "", "", 25 },
+            })
+
+            lfs._setFileState(kepub_path, {
+                exists = true,
+                attributes = { mode = "directory" },
+            })
+            lfs._setDirectoryContents(kepub_path, { ".", "..", "ACCESSIBLE" })
+            lfs._setFileState(kepub_path .. "/ACCESSIBLE", {
+                exists = true,
+                attributes = { mode = "file" },
+            })
+
+            lfs._setFileState("/mnt/onboard/My Book.epub", {
+                exists = true,
+                attributes = { mode = "file" },
+            })
+
+            local accessible = parser:getAccessibleBooks()
+            assert.equals(1, #accessible)
+            assert.equals("ACCESSIBLE", accessible[1].id)
+
+            local sideloaded = parser:getSideloadedBooks()
+            assert.equals(1, #sideloaded)
+            assert.equals("file:///mnt/onboard/My%20Book.epub", sideloaded[1].id)
+        end)
+    end)
+
     describe("clearCache", function()
         local SQ3
 

--- a/spec/metadata_parser_spec.lua
+++ b/spec/metadata_parser_spec.lua
@@ -803,6 +803,69 @@ describe("MetadataParser", function()
             assert.equals(1, #sideloaded)
             assert.equals("file:///mnt/onboard/My%20Book.epub", sideloaded[1].id)
         end)
+
+        it("should drop a sideloaded book whose file is deleted, even with an unchanged database mtime", function()
+            local parser = MetadataParser:new()
+            parser.db_path = "/tmp/.kobo/KoboReader.sqlite"
+            local kepub_path = parser:getKepubPath()
+            local db_path = parser:getDatabasePath()
+
+            lfs._setFileState(db_path, {
+                exists = true,
+                attributes = { size = 100, mode = "file", modification = 1000000000 },
+            })
+            SQ3._setBookRows({
+                { "file:///mnt/onboard/My%20Book.epub", "Sideloaded Book", "Author", "", "", "", 25 },
+            })
+
+            lfs._setFileState(kepub_path, { exists = true, attributes = { mode = "directory" } })
+            lfs._setDirectoryContents(kepub_path, { ".", ".." })
+
+            lfs._setFileState("/mnt/onboard/My Book.epub", {
+                exists = true,
+                attributes = { mode = "file" },
+            })
+
+            assert.equals(1, #parser:getSideloadedBooks())
+
+            -- File is removed on disk; database mtime stays unchanged.
+            lfs._setFileState("/mnt/onboard/My Book.epub", { exists = false, attributes = nil })
+
+            local sideloaded = parser:getSideloadedBooks()
+            assert.equals(0, #sideloaded)
+        end)
+
+        it("should include a sideloaded book whose file is restored, even with an unchanged database mtime", function()
+            local parser = MetadataParser:new()
+            parser.db_path = "/tmp/.kobo/KoboReader.sqlite"
+            local kepub_path = parser:getKepubPath()
+            local db_path = parser:getDatabasePath()
+
+            lfs._setFileState(db_path, {
+                exists = true,
+                attributes = { size = 100, mode = "file", modification = 1000000000 },
+            })
+            SQ3._setBookRows({
+                { "file:///mnt/onboard/My%20Book.epub", "Sideloaded Book", "Author", "", "", "", 25 },
+            })
+
+            lfs._setFileState(kepub_path, { exists = true, attributes = { mode = "directory" } })
+            lfs._setDirectoryContents(kepub_path, { ".", ".." })
+
+            lfs._setFileState("/mnt/onboard/My Book.epub", { exists = false, attributes = nil })
+
+            assert.equals(0, #parser:getSideloadedBooks())
+
+            -- File reappears on disk; database mtime stays unchanged.
+            lfs._setFileState("/mnt/onboard/My Book.epub", {
+                exists = true,
+                attributes = { mode = "file" },
+            })
+
+            local sideloaded = parser:getSideloadedBooks()
+            assert.equals(1, #sideloaded)
+            assert.equals("file:///mnt/onboard/My%20Book.epub", sideloaded[1].id)
+        end)
     end)
 
     describe("clearCache", function()

--- a/src/lib/kobo_state_reader.lua
+++ b/src/lib/kobo_state_reader.lua
@@ -104,6 +104,9 @@ end
 --- Calculates reading progress from chapter data.
 --- Uses ___FileOffset (chapter start position) directly from Kobo database.
 ---
+--- Uses Chapter.BookID and Chapter.Title to find the chapter entry in the database,
+--- as Chapter.Title is the filename of the chapter and Chapter.BookID is the ContentID of the book.
+---
 --- Example calculation:
 ---   Chapter starts at 20% (___FileOffset = 20)
 ---   Chapter size is 1.37% (___FileSize = 1.36992)
@@ -123,23 +126,26 @@ local function calculateChapterProgress(conn, book_id, chapter_id_bookmarked)
     end
 
     local filename = chapter_id_bookmarked:match("^([^#]+)") or chapter_id_bookmarked
-    local chapter_lookup = conn:exec(
-        string.format(
-            "SELECT ContentID, ___FileOffset, ___FileSize, ___PercentRead FROM content WHERE ContentID LIKE '%s%%' AND ContentType = 9 AND (ContentID LIKE '%%%s' OR ContentID LIKE '%%%s#%%') LIMIT 1",
-            book_id,
-            filename,
-            filename
-        )
-    )
+    local stmt = conn:prepare([[
+        SELECT ContentID, ___FileOffset, ___FileSize, ___PercentRead
+        FROM content
+        WHERE BookID = ?
+            AND ContentType = 9
+            AND Title = ?
+        LIMIT 1
+        ]])
+    stmt:bind(book_id, filename)
+    local chapter_lookup = stmt:step()
+    stmt:close()
 
-    if not chapter_lookup or not chapter_lookup[1] or not chapter_lookup[1][1] then
+    if not chapter_lookup or not chapter_lookup[1] then
         logger.warn("KoboPlugin: Could not find ContentID for bookmarked chapter:", chapter_id_bookmarked)
         return 0
     end
 
-    local chapter_start_percent = tonumber(chapter_lookup[2][1]) or 0
-    local chapter_size_percent = tonumber(chapter_lookup[3][1]) or 0
-    local chapter_progress_percent = tonumber(chapter_lookup[4][1]) or 0
+    local chapter_start_percent = tonumber(chapter_lookup[2]) or 0
+    local chapter_size_percent = tonumber(chapter_lookup[3]) or 0
+    local chapter_progress_percent = tonumber(chapter_lookup[4]) or 0
 
     local chapter_contribution_percent = (chapter_size_percent * chapter_progress_percent) / 100.0
 

--- a/src/lib/kobo_state_reader.lua
+++ b/src/lib/kobo_state_reader.lua
@@ -104,6 +104,9 @@ end
 --- Calculates reading progress from chapter data.
 --- Uses ___FileOffset (chapter start position) directly from Kobo database.
 ---
+--- Uses Chapter.BookID and Chapter.Title to find the chapter entry in the database,
+--- as Chapter.Title is the filename of the chapter and Chapter.BookID is the ContentID of the book.
+---
 --- Example calculation:
 ---   Chapter starts at 20% (___FileOffset = 20)
 ---   Chapter size is 1.37% (___FileSize = 1.36992)
@@ -123,11 +126,12 @@ local function calculateChapterProgress(conn, book_id, chapter_id_bookmarked)
     end
 
     local filename = chapter_id_bookmarked:match("^([^#]+)") or chapter_id_bookmarked
+    -- Chapter.BookID == Book.ContentID
+    -- Chapter.Title == filename
     local chapter_lookup = conn:exec(
         string.format(
-            "SELECT ContentID, ___FileOffset, ___FileSize, ___PercentRead FROM content WHERE ContentID LIKE '%s%%' AND ContentType = 9 AND (ContentID LIKE '%%%s' OR ContentID LIKE '%%%s#%%') LIMIT 1",
+            "SELECT ContentID, ___FileOffset, ___FileSize, ___PercentRead FROM content WHERE BookID = '%s' AND ContentType = 9 AND Title = '%s' LIMIT 1",
             book_id,
-            filename,
             filename
         )
     )

--- a/src/lib/kobo_state_writer.lua
+++ b/src/lib/kobo_state_writer.lua
@@ -93,22 +93,28 @@ end
 ---
 --- Extracts the filename portion from a ContentID.
 ---
---- Kobo ContentIDs are in format: "BOOKID!!filename.html"
---- This function extracts just "filename.html" for use in bookmarks.
+--- Kobo ContentIDs are in format: "BOOKID!Path!To!filename.html"
+--- This function extracts just "Path/To/filename.html" for use in bookmarks.
 ---
 --- @param content_id string: Full ContentID.
 --- @return string: Filename portion of ContentID.
 local function extractFilename(content_id)
-    if not content_id:match("!!") then
+    local result = content_id:match("!(.*)$")
+    if not result then
         return content_id
     end
 
-    return content_id:match("!!(.+)$")
+    result = result:gsub("!", "/")
+    result = result:gsub("^/+", "")
+
+    return result
 end
 
 ---
 --- Finds the appropriate chapter for a given reading percentage.
 --- Uses SQL WHERE clause with ___FileOffset to efficiently find the chapter.
+---
+--- Uses the chapter's BookID to link it to the book by its ContentID
 ---
 --- Example calculation:
 ---   Target overall progress: 20.5%
@@ -128,7 +134,7 @@ end
 local function findChapterForPercentage(conn, book_id, percent_read)
     local chapters_res = conn:exec(
         string.format(
-            "SELECT ContentID, ___FileOffset, ___FileSize FROM content WHERE ContentID LIKE '%s%%%%' AND ContentType = 9 AND ___FileOffset <= %f ORDER BY ___FileOffset DESC LIMIT 1",
+            "SELECT ContentID, ___FileOffset, ___FileSize FROM content WHERE BookID = '%s' AND ContentType = 9 AND ___FileOffset <= %f ORDER BY ___FileOffset DESC LIMIT 1",
             book_id,
             percent_read
         )

--- a/src/lib/kobo_state_writer.lua
+++ b/src/lib/kobo_state_writer.lua
@@ -93,22 +93,28 @@ end
 ---
 --- Extracts the filename portion from a ContentID.
 ---
---- Kobo ContentIDs are in format: "BOOKID!!filename.html"
---- This function extracts just "filename.html" for use in bookmarks.
+--- Kobo ContentIDs are in format: "BOOKID!Path!To!filename.html"
+--- This function extracts just "Path/To/filename.html" for use in bookmarks.
 ---
 --- @param content_id string: Full ContentID.
 --- @return string: Filename portion of ContentID.
 local function extractFilename(content_id)
-    if not content_id:match("!!") then
+    local result = content_id:match("!(.*)$")
+    if not result then
         return content_id
     end
 
-    return content_id:match("!!(.+)$")
+    result = result:gsub("!", "/")
+    result = result:gsub("^/+", "")
+
+    return result
 end
 
 ---
 --- Finds the appropriate chapter for a given reading percentage.
 --- Uses SQL WHERE clause with ___FileOffset to efficiently find the chapter.
+---
+--- Uses the chapter's BookID to link it to the book by its ContentID
 ---
 --- Example calculation:
 ---   Target overall progress: 20.5%
@@ -126,9 +132,10 @@ end
 --- @return number: Chapter progress percentage (0-100).
 --- @return string|nil: Chapter ContentID, or nil if not found.
 local function findChapterForPercentage(conn, book_id, percent_read)
+    -- Chapter.BookID == Book.ContentID
     local chapters_res = conn:exec(
         string.format(
-            "SELECT ContentID, ___FileOffset, ___FileSize FROM content WHERE ContentID LIKE '%s%%%%' AND ContentType = 9 AND ___FileOffset <= %f ORDER BY ___FileOffset DESC LIMIT 1",
+            "SELECT ContentID, ___FileOffset, ___FileSize FROM content WHERE BookID = '%s' AND ContentType = 9 AND ___FileOffset <= %f ORDER BY ___FileOffset DESC LIMIT 1",
             book_id,
             percent_read
         )

--- a/src/metadata_parser.lua
+++ b/src/metadata_parser.lua
@@ -11,6 +11,8 @@ local logger = require("logger")
 
 local MetadataParser = {}
 
+local FILE_URI_PREFIX = "file://"
+
 ---
 --- Creates a new MetadataParser instance.
 --- Initializes with empty metadata cache and no database path.
@@ -18,9 +20,12 @@ local MetadataParser = {}
 function MetadataParser:new()
     local o = {
         metadata = nil,
+        sideloaded_metadata = nil,
         db_path = nil,
         last_mtime = nil,
+        sideloaded_last_mtime = nil,
         accessible_books = nil,
+        sideloaded_books = nil,
         plugin = nil,
     }
     setmetatable(o, self)
@@ -100,6 +105,31 @@ function MetadataParser:needsReload()
 end
 
 ---
+--- Checks whether cached sideloaded_metadata needs to be reloaded from database.
+--- Reload is needed when: sideloaded_metadata is nil, sideloaded_last_mtime is nil,
+--- database file disappeared but we had cached data, or database
+--- modification time is newer than our cached version.
+--- @return boolean: True if sideloaded_metadata should be reloaded.
+function MetadataParser:needsSideloadedMetadataReload()
+    local db_path = self:getDatabasePath()
+    local attr = lfs.attributes(db_path)
+
+    if not attr then
+        return self.sideloaded_metadata ~= nil
+    end
+
+    if not self.sideloaded_metadata then
+        return true
+    end
+
+    if not self.sideloaded_last_mtime then
+        return true
+    end
+
+    return attr.modification > self.sideloaded_last_mtime
+end
+
+---
 --- Checks whether cached accessible books need to be reloaded.
 --- Reload is needed when: accessible_books is nil, or when metadata needs reload.
 --- @return boolean: True if accessible books cache should be reloaded.
@@ -108,17 +138,44 @@ function MetadataParser:needsAccessibleBooksReload()
 end
 
 ---
+--- Checks whether cached sideloaded books need to be reloaded.
+--- Reload if needed when: sideloaded_books is nil, or when sideloaded metadata needs reload.
+--- @return boolean: True if sideloaded books cache should be reloaded.
+function MetadataParser:needsSideloadedBooksReload()
+    return self.sideloaded_books == nil or self:needsSideloadedMetadataReload()
+end
+
+---
 --- Gets the SQL query for fetching book metadata from KoboReader.sqlite.
 --- Query selects all books (ContentType = 6) from the content table.
 --- Excludes file:// prefixed paths, they are excluded because these are sideloaded files not stored in kepub directory.
 --- @return string: SQL query string.
 local function getBookMetadataQuery()
-    return [[
+    return string.format(
+        [[
         SELECT ContentID, Title, Attribution, Publisher, Series, SeriesNumber, ___PercentRead
         FROM content
         WHERE ContentType = 6
-        AND ContentID NOT LIKE 'file://%'
-    ]]
+        AND ContentID NOT LIKE '%s%%'
+    ]],
+        FILE_URI_PREFIX
+    )
+end
+
+---
+--- Gets the SQL query for fetching sideloaded metadata from KoboReader.sqlite.
+--- Query selects only sideloaded books where ContentID is a file:// URI.
+--- @return string: SQL query string.
+local function getSideloadedBookMetadataQuery()
+    return string.format(
+        [[
+        SELECT ContentID, Title, Attribution, Publisher, Series, SeriesNumber, ___PercentRead
+        FROM content
+        WHERE ContentType = 6
+        AND ContentID LIKE '%s%%'
+    ]],
+        FILE_URI_PREFIX
+    )
 end
 
 ---
@@ -161,6 +218,28 @@ local function openDatabaseAndPrepareQuery(db_path)
     end
 
     local stmt = conn:prepare(getBookMetadataQuery())
+    if not stmt then
+        logger.err("KoboPlugin: Failed to prepare query")
+        conn:close()
+        return nil, nil
+    end
+
+    return conn, stmt
+end
+
+---
+--- Opens the database and prepares the sideloaded metadata query statement.
+--- @param db_path string: Path to the KoboReader.sqlite database.
+--- @return table|nil: Database connection object.
+--- @return table|nil: Prepared statement object.
+local function openDatabaseAndPrepareQueryForSideloadedMetadata(db_path)
+    local conn = SQ3.open(db_path)
+    if not conn then
+        logger.err("KoboPlugin: Failed to open Kobo database:", db_path)
+        return nil, nil
+    end
+
+    local stmt = conn:prepare(getSideloadedBookMetadataQuery())
     if not stmt then
         logger.err("KoboPlugin: Failed to prepare query")
         conn:close()
@@ -228,6 +307,75 @@ function MetadataParser:parseMetadata()
     return self.metadata
 end
 
+--- Parses the KoboReader.sqlite database to extract sideloaded metadata.
+--- Returns empty table if database is missing or cannot be opened.
+--- Updates self.sideloaded_metadata and self.sideloaded_last_mtime on success.
+--- @return table: Metadata table keyed by book ContentID, or empty table on failure.
+function MetadataParser:parseSideloadedMetadata()
+    local db_path = self:getDatabasePath()
+
+    logger.dbg("KoboPlugin: Using database path:", db_path)
+
+    local attr = lfs.attributes(db_path)
+    if not attr then
+        logger.warn("KoboPlugin: Kobo database not found at:", db_path)
+        self.sideloaded_metadata = {}
+        return self.sideloaded_metadata
+    end
+
+    logger.dbg("KoboPlugin: Database found, size:", attr.size, "bytes")
+
+    local conn, stmt = openDatabaseAndPrepareQueryForSideloadedMetadata(db_path)
+    if not conn or not stmt then
+        self.sideloaded_metadata = {}
+        return self.sideloaded_metadata
+    end
+
+    logger.dbg("KoboPlugin: Executing query...")
+
+    local sideloaded_metadata, book_count = parseBookRows(stmt)
+
+    stmt:close()
+    conn:close()
+
+    self.sideloaded_metadata = sideloaded_metadata
+    self.sideloaded_last_mtime = attr.modification
+
+    logger.info("KoboPlugin: Loaded sideloaded metadata for", book_count, "books from SQLite database")
+    return self.sideloaded_metadata
+end
+
+---
+--- Checks whether a ContentID belongs to a sideloaded book.
+--- Sideloaded entries in Kobo DB use a file:// URI as ContentID.
+--- @param book_id string
+--- @return boolean
+local function isSideloadedBookId(book_id)
+    if type(book_id) ~= "string" then
+        return false
+    end
+
+    return book_id:sub(1, #FILE_URI_PREFIX) == FILE_URI_PREFIX
+end
+
+---
+--- Converts a file:// ContentID into a filesystem path.
+--- Also decodes percent-encoded bytes so paths with spaces can be opened.
+--- @param file_uri string
+--- @return string|nil
+local function decodeFileUriToPath(file_uri)
+    if not isSideloadedBookId(file_uri) then
+        return nil
+    end
+
+    local path = file_uri:sub(#FILE_URI_PREFIX + 1)
+    path = path:gsub("%%(%x%x)", function(hex)
+        return string.char(tonumber(hex, 16))
+    end)
+
+    return path
+end
+
 ---
 --- Gets the metadata cache, reloading from database if stale.
 --- Automatically calls parseMetadata if needsReload returns true.
@@ -237,6 +385,17 @@ function MetadataParser:getMetadata()
         self:parseMetadata()
     end
     return self.metadata or {}
+end
+
+---
+--- Gets the sideloaded metadata cache, reloading from database if stale.
+--- Automatically calls parseSideloadedMetadata if needsSideloadedMetadataReload returns true.
+--- @return table: Metadata table keyed by book ContentID, never nil.
+function MetadataParser:getSideloadedMetadata()
+    if self:needsSideloadedMetadataReload() then
+        self:parseSideloadedMetadata()
+    end
+    return self.sideloaded_metadata or {}
 end
 
 ---
@@ -614,6 +773,49 @@ local function _buildAccessibleBooks(self)
 end
 
 ---
+--- Filters sideloaded metadata to return only sideloaded books with existing files.
+---
+--- @return table: Array of sideloaded book entries, each containing id, metadata, filepath, and thumbnail.
+local function _buildSideloadedBooks(self)
+    local sideloaded_books = {}
+
+    local sideloaded_metadata = self:getSideloadedMetadata()
+
+    local sideloaded_total = 0
+    local sideloaded_accessible = 0
+
+    for book_id, book_meta in pairs(sideloaded_metadata) do
+        if not isSideloadedBookId(book_id) then
+            goto continue
+        end
+
+        sideloaded_total = sideloaded_total + 1
+
+        local filepath = decodeFileUriToPath(book_id)
+        if not filepath then
+            goto continue
+        end
+
+        local mode = lfs.attributes(filepath, "mode")
+        if mode ~= "file" then
+            goto continue
+        end
+
+        local entry = createAccessibleBookEntry(book_id, book_meta, filepath, nil)
+        entry.is_sideloaded = true
+
+        table.insert(sideloaded_books, entry)
+        sideloaded_accessible = sideloaded_accessible + 1
+
+        ::continue::
+    end
+
+    logger.info("KoboPlugin: Sideloaded books total:", sideloaded_accessible, "from metadata:", sideloaded_total)
+
+    return sideloaded_books
+end
+
+---
 --- Gets the accessible books cache, reloading from disk if stale.
 --- Automatically calls _buildAccessibleBooks if needsAccessibleBooksReload returns true.
 --- @return table: Array of accessible book entries, never nil.
@@ -626,13 +828,28 @@ function MetadataParser:getAccessibleBooks()
 end
 
 ---
+--- Gets the sideloaded books cache, reloading from disk if stale.
+--- Automatically calls _buildSideloadedBooks if needsSideloadedBooksReload returns true.
+--- @return table: Array of sideloaded book entries, never nil.
+function MetadataParser:getSideloadedBooks()
+    if self:needsSideloadedBooksReload() then
+        self.sideloaded_books = _buildSideloadedBooks(self)
+    end
+
+    return self.sideloaded_books or {}
+end
+
+---
 --- Clears the metadata cache, forcing a reload on next access.
 --- Resets both the metadata table and the last modification time.
 --- Also clears the accessible books cache.
 function MetadataParser:clearCache()
     self.metadata = nil
+    self.sideloaded_metadata = nil
     self.last_mtime = nil
+    self.sideloaded_last_mtime = nil
     self.accessible_books = nil
+    self.sideloaded_books = nil
 end
 
 return MetadataParser

--- a/src/metadata_parser.lua
+++ b/src/metadata_parser.lua
@@ -26,6 +26,7 @@ function MetadataParser:new()
         sideloaded_last_mtime = nil,
         accessible_books = nil,
         sideloaded_books = nil,
+        sideloaded_fs_state = nil,
         plugin = nil,
     }
     setmetatable(o, self)
@@ -138,11 +139,36 @@ function MetadataParser:needsAccessibleBooksReload()
 end
 
 ---
+--- Checks whether a tracked sideloaded file's on-disk state (existence/mtime)
+--- changed since the last scan. Catches files deleted, restored, or replaced
+--- while the database (and thus its mtime) is unchanged.
+--- @return boolean: True if any sideloaded file's fs state changed.
+function MetadataParser:_sideloadedFsStateChanged()
+    local current_state = self:_scanSideloadedFsState()
+    local cached_state = self.sideloaded_fs_state or {}
+
+    for book_id, state in pairs(current_state) do
+        if cached_state[book_id] ~= state then
+            return true
+        end
+    end
+
+    for book_id, state in pairs(cached_state) do
+        if current_state[book_id] ~= state then
+            return true
+        end
+    end
+
+    return false
+end
+
+---
 --- Checks whether cached sideloaded books need to be reloaded.
---- Reload if needed when: sideloaded_books is nil, or when sideloaded metadata needs reload.
+--- Reload is needed when: sideloaded_books is nil, sideloaded metadata needs reload,
+--- or a tracked sideloaded file's on-disk state changed (see _sideloadedFsStateChanged).
 --- @return boolean: True if sideloaded books cache should be reloaded.
 function MetadataParser:needsSideloadedBooksReload()
-    return self.sideloaded_books == nil or self:needsSideloadedMetadataReload()
+    return self.sideloaded_books == nil or self:needsSideloadedMetadataReload() or self:_sideloadedFsStateChanged()
 end
 
 ---
@@ -773,6 +799,26 @@ local function _buildAccessibleBooks(self)
 end
 
 ---
+--- Scans the on-disk state (existence and modification time) of every sideloaded
+--- file referenced by the cached sideloaded metadata. Used to detect files deleted,
+--- restored, or replaced without a corresponding change in the Kobo database mtime.
+--- @return table: Map of book_id -> modification time (or true if unavailable), false when the file is missing.
+function MetadataParser:_scanSideloadedFsState()
+    local state = {}
+
+    for book_id in pairs(self:getSideloadedMetadata()) do
+        if isSideloadedBookId(book_id) then
+            local filepath = decodeFileUriToPath(book_id)
+            local attr = filepath and lfs.attributes(filepath)
+
+            state[book_id] = (attr and attr.mode == "file") and (attr.modification or true) or false
+        end
+    end
+
+    return state
+end
+
+---
 --- Filters sideloaded metadata to return only sideloaded books with existing files.
 ---
 --- @return table: Array of sideloaded book entries, each containing id, metadata, filepath, and thumbnail.
@@ -780,6 +826,7 @@ local function _buildSideloadedBooks(self)
     local sideloaded_books = {}
 
     local sideloaded_metadata = self:getSideloadedMetadata()
+    local fs_state = self:_scanSideloadedFsState()
 
     local sideloaded_total = 0
     local sideloaded_accessible = 0
@@ -791,16 +838,11 @@ local function _buildSideloadedBooks(self)
 
         sideloaded_total = sideloaded_total + 1
 
+        if not fs_state[book_id] then
+            goto continue
+        end
+
         local filepath = decodeFileUriToPath(book_id)
-        if not filepath then
-            goto continue
-        end
-
-        local mode = lfs.attributes(filepath, "mode")
-        if mode ~= "file" then
-            goto continue
-        end
-
         local entry = createAccessibleBookEntry(book_id, book_meta, filepath, nil)
         entry.is_sideloaded = true
 
@@ -809,6 +851,8 @@ local function _buildSideloadedBooks(self)
 
         ::continue::
     end
+
+    self.sideloaded_fs_state = fs_state
 
     logger.info("KoboPlugin: Sideloaded books total:", sideloaded_accessible, "from metadata:", sideloaded_total)
 
@@ -828,7 +872,8 @@ function MetadataParser:getAccessibleBooks()
 end
 
 ---
---- Gets the sideloaded books cache, reloading from disk if stale.
+--- Gets the sideloaded books cache, reloading when the sideloaded metadata or the
+--- on-disk state (existence/mtime) of any tracked sideloaded file has changed.
 --- Automatically calls _buildSideloadedBooks if needsSideloadedBooksReload returns true.
 --- @return table: Array of sideloaded book entries, never nil.
 function MetadataParser:getSideloadedBooks()
@@ -850,6 +895,7 @@ function MetadataParser:clearCache()
     self.sideloaded_last_mtime = nil
     self.accessible_books = nil
     self.sideloaded_books = nil
+    self.sideloaded_fs_state = nil
 end
 
 return MetadataParser

--- a/src/reading_state_sync.lua
+++ b/src/reading_state_sync.lua
@@ -128,6 +128,12 @@ function ReadingStateSync:getBookTitle(book_id, doc_settings)
     end
 
     local book_meta = self.metadata_parser:getBookMetadata(book_id)
+
+    if not book_meta and self.metadata_parser.getSideloadedMetadata then
+        local sideloaded_metadata = self.metadata_parser:getSideloadedMetadata()
+        book_meta = sideloaded_metadata[book_id]
+    end
+
     if book_meta and book_meta.title and book_meta.title ~= "" then
         return book_meta.title
     end
@@ -610,9 +616,11 @@ function ReadingStateSync:syncBidirectional(book_id, doc_settings)
 
     if kobo_state.timestamp > kr_timestamp then
         return self:executePullFromKobo(book_id, doc_settings, kobo_state, kr_percent, kr_timestamp)
+    elseif kr_timestamp > kobo_state.timestamp then
+        return self:executePushToKobo(book_id, doc_settings, kobo_state, kr_percent, kr_timestamp)
     end
 
-    return self:executePushToKobo(book_id, doc_settings, kobo_state, kr_percent, kr_timestamp)
+    return false
 end
 
 ---
@@ -683,8 +691,18 @@ function ReadingStateSync:syncAllBooks()
     end
 
     local accessible_books = self.metadata_parser:getAccessibleBooks()
+    local sideloaded_books = self.metadata_parser:getSideloadedBooks()
+    local books_to_sync = {}
 
-    logger.info("KoboPlugin: Starting manual sync for", #accessible_books, "accessible books")
+    for _, book in ipairs(accessible_books) do
+        table.insert(books_to_sync, book)
+    end
+
+    for _, book in ipairs(sideloaded_books) do
+        table.insert(books_to_sync, book)
+    end
+
+    logger.info("KoboPlugin: Starting manual sync for", #books_to_sync, "books (kobo + sideloaded)")
 
     Trapper:setPausedText(_("Do you want to abort sync?"), _("Abort"), _("Continue"))
 
@@ -697,11 +715,11 @@ function ReadingStateSync:syncAllBooks()
 
     local synced_count = 0
 
-    for i, book in ipairs(accessible_books) do
-        go_on = Trapper:info(T(_("Syncing: %1 / %2"), i, #accessible_books))
+    for i, book in ipairs(books_to_sync) do
+        go_on = Trapper:info(T(_("Syncing: %1 / %2"), i, #books_to_sync))
 
         if not go_on then
-            logger.info("KoboPlugin: Manual sync aborted by user at book", i, "of", #accessible_books)
+            logger.info("KoboPlugin: Manual sync aborted by user at book", i, "of", #books_to_sync)
             Trapper:clear()
             return synced_count
         end
@@ -711,7 +729,7 @@ function ReadingStateSync:syncAllBooks()
         end
     end
 
-    logger.info("KoboPlugin: Manual sync completed -", synced_count, "books synced out of", #accessible_books)
+    logger.info("KoboPlugin: Manual sync completed -", synced_count, "books synced out of", #books_to_sync)
 
     if synced_count > 0 then
         self:invalidateMetadataCaches()


### PR DESCRIPTION
Closes #183 

## Summary
The sideloaded books weren't included in manual synchronisation.
This PR adds a new set of books to synchronise when calling `syncAllBooks`.

## Test Plan

- [x] Added unit test in `spec/metadata_parser_spec.lua` asserting that:
  - [x] Only existing books are included.
  - [x] Accessible books and side loaded books do not get mixed.
- [x] Verified on device (Kobo, KOReader v2026.03, kobo.koplugin 0.4.1): sideloaded books get synchronised both ways.