### PR TITLE
fix(progress sync): take into consideration timezone offsets

### DIFF
--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -1002,6 +1002,10 @@ local function createIOOpenMocker()
 end
 -- Mock lua-ljsqlite3 module
 if not package.preload["lua-ljsqlite3/init"] then
+    -- Allows tests to override the DateLastRead value returned for any book,
+    -- e.g. to exercise timezone parsing in parseKoboTimestamp.
+    local custom_date_last_read = nil
+
     -- Helper functions for query result logic
     ---
     -- Returns mock results for main book entry queries based on the query string.
@@ -1009,6 +1013,15 @@ if not package.preload["lua-ljsqlite3/init"] then
     -- @param query string: The SQL query string.
     -- @return table: Mocked result rows.
     local function result_main_book_entry(query)
+        if custom_date_last_read then
+            return {
+                { custom_date_last_read },
+                { 1 },
+                { "test_book_1!!chapter_5.html#kobo.1.1" },
+                { 0 },
+            }
+        end
+
         if query:match("finished_book") then
             return {
                 { "2025-11-08 15:30:45.000+00:00" },
@@ -1234,12 +1247,20 @@ if not package.preload["lua-ljsqlite3/init"] then
                 mock_db_state.content_keys = keys or {}
             end,
             ---
+            -- Override the DateLastRead string returned for the main book entry query.
+            -- Used to test parseKoboTimestamp's timezone handling regardless of book ID.
+            -- @param value string|nil: Date string to return, or nil to clear the override.
+            _setDateLastRead = function(value)
+                custom_date_last_read = value
+            end,
+            ---
             -- Clear all mock database state.
             _clearMockState = function()
                 mock_db_state.should_fail_open = false
                 mock_db_state.should_fail_prepare = false
                 mock_db_state.book_rows = {}
                 mock_db_state.content_keys = {}
+                custom_date_last_read = nil
             end,
             open = function(path, flags)
                 if mock_db_state.should_fail_open then
@@ -1327,21 +1348,43 @@ if not package.preload["lua-ljsqlite3/init"] then
     end
 end
 
+---
+--- Creates a mock ReadHistory module table.
+---
+--- Mirrors KOReader's real ReadHistory:addItem(file, ts) semantics: if an
+--- entry for `file` already exists, it is removed first, then the new entry
+--- is inserted at the FRONT of the history (most recent first). This is NOT
+--- a plain append - callers relying on `hist[1]` being the latest entry, or
+--- on a file appearing only once, depend on this behavior.
+--- @param hist table|nil: Initial history entries (array of {file=, time=}).
+--- @return table: Mock ReadHistory module with hist, addItem and addRecord.
+local function createMockReadHistory(hist)
+    local history = hist or {}
+
+    return {
+        hist = history,
+        addItem = function(self, file, ts)
+            for i, entry in ipairs(self.hist) do
+                if entry.file == file then
+                    table.remove(self.hist, i)
+                    break
+                end
+            end
+            table.insert(self.hist, 1, { file = file, time = ts })
+        end,
+        addRecord = function(self, record)
+            table.insert(self.hist, record)
+        end,
+    }
+end
+
 -- Mock readhistory module
 if not package.preload["readhistory"] then
     package.preload["readhistory"] = function()
-        return {
-            hist = {
-                { file = "/test/book1.epub", time = 1699500000 },
-                { file = "/test/book2.epub", time = 1699600000 },
-            },
-            addItem = function(self, file, ts)
-                table.insert(self.hist, { file = file, time = ts })
-            end,
-            addRecord = function(self, record)
-                table.insert(self.hist, record)
-            end,
-        }
+        return createMockReadHistory({
+            { file = "/test/book1.epub", time = 1699500000 },
+            { file = "/test/book2.epub", time = 1699600000 },
+        })
     end
 end
 
@@ -2192,6 +2235,7 @@ end
 
 return {
     createMockDocSettings = createMockDocSettings,
+    createMockReadHistory = createMockReadHistory,
     resetUIMocks = resetUIMocks,
     createIOOpenMocker = createIOOpenMocker,
 }

--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -1335,6 +1335,9 @@ if not package.preload["readhistory"] then
                 { file = "/test/book1.epub", time = 1699500000 },
                 { file = "/test/book2.epub", time = 1699600000 },
             },
+            addItem = function(self, file, ts)
+                table.insert(self.hist, { file = file, time = ts })
+            end,
             addRecord = function(self, record)
                 table.insert(self.hist, record)
             end,

--- a/spec/kobo_state_reader_spec.lua
+++ b/spec/kobo_state_reader_spec.lua
@@ -1,0 +1,79 @@
+-- Tests for KoboStateReader
+
+describe("KoboStateReader timestamp parsing", function()
+    local KoboStateReader
+    local SQ3
+
+    setup(function()
+        require("spec/helper")
+        SQ3 = require("lua-ljsqlite3/init")
+    end)
+
+    before_each(function()
+        package.loaded["src/lib/kobo_state_reader"] = nil
+        KoboStateReader = require("src/lib/kobo_state_reader")
+        SQ3._clearMockState()
+    end)
+
+    after_each(function()
+        SQ3._clearMockState()
+    end)
+
+    local function readTimestamp(date_string)
+        SQ3._setDateLastRead(date_string)
+        local state = KoboStateReader.read("/fake/db.sqlite", "test_book_1")
+        assert.is_not_nil(state)
+        return state.timestamp
+    end
+
+    it("returns 0 when DateLastRead is empty", function()
+        assert.equals(0, readTimestamp(""))
+    end)
+
+    it("returns 0 when DateLastRead does not match a known date format", function()
+        assert.equals(0, readTimestamp("not-a-date"))
+    end)
+
+    it("treats a datetime without a timezone as local time", function()
+        -- Local time with no suffix: os.time() should parse the fields as
+        -- local wall-clock time.
+        local expected = os.time({ year = 2025, month = 11, day = 8, hour = 15, min = 30, sec = 45 })
+        assert.equals(expected, readTimestamp("2025-11-08T15:30:45"))
+    end)
+
+    it("accepts a space separator instead of 'T'", function()
+        local expected = os.time({ year = 2025, month = 11, day = 8, hour = 15, min = 30, sec = 45 })
+        assert.equals(expected, readTimestamp("2025-11-08 15:30:45"))
+    end)
+
+    it("treats the legacy '+00:00' offset with milliseconds the same as 'Z'", function()
+        local z_ts = readTimestamp("2025-11-08T15:30:45Z")
+        local legacy_ts = readTimestamp("2025-11-08 15:30:45.000+00:00")
+        assert.equals(z_ts, legacy_ts)
+    end)
+
+    it("applies a positive UTC offset relative to 'Z'", function()
+        local z_ts = readTimestamp("2025-11-08T15:30:45Z")
+        local plus_two_ts = readTimestamp("2025-11-08T15:30:45+02:00")
+
+        -- 15:30:45+02:00 is 2 hours *earlier* in UTC than 15:30:45Z,
+        -- so its resulting local timestamp should be 2 hours behind.
+        assert.equals(2 * 3600, z_ts - plus_two_ts)
+    end)
+
+    it("applies a negative UTC offset relative to 'Z'", function()
+        local z_ts = readTimestamp("2025-11-08T15:30:45Z")
+        local minus_five_ts = readTimestamp("2025-11-08T15:30:45-05:00")
+
+        -- 15:30:45-05:00 is 5 hours *later* in UTC than 15:30:45Z,
+        -- so its resulting local timestamp should be 5 hours ahead.
+        assert.equals(5 * 3600, minus_five_ts - z_ts)
+    end)
+
+    it("keeps offsets consistent across the day boundary", function()
+        local z_ts = readTimestamp("2025-11-08T00:30:00Z")
+        local plus_two_ts = readTimestamp("2025-11-08T00:30:00+02:00")
+
+        assert.equals(2 * 3600, z_ts - plus_two_ts)
+    end)
+end)

--- a/spec/kobo_state_writer_spec.lua
+++ b/spec/kobo_state_writer_spec.lua
@@ -1,0 +1,62 @@
+-- Tests for KoboStateWriter
+
+describe("KoboStateWriter timestamp formatting", function()
+    local KoboStateWriter
+    local SQ3
+
+    setup(function()
+        require("spec/helper")
+        SQ3 = require("lua-ljsqlite3/init")
+    end)
+
+    before_each(function()
+        package.loaded["src/lib/kobo_state_writer"] = nil
+        KoboStateWriter = require("src/lib/kobo_state_writer")
+        SQ3._clearMockState()
+        SQ3._clearSqlQueries()
+    end)
+
+    after_each(function()
+        SQ3._clearMockState()
+    end)
+
+    local function findMainEntryUpdateDateParam()
+        local queries = SQ3._getSqlQueries()
+
+        for _, captured in ipairs(queries) do
+            if captured.query:match("ContentType = 6") and captured.query:match("DateLastRead") then
+                return captured.params[2]
+            end
+        end
+
+        return nil
+    end
+
+    it("writes the timestamp as 'YYYY-MM-DDTHH:MM:SSZ'", function()
+        local timestamp = os.time({ year = 2025, month = 11, day = 8, hour = 15, min = 30, sec = 45 })
+
+        KoboStateWriter.write("/fake/db.sqlite", "test_book_1", 35, timestamp, "reading")
+
+        local date_str = findMainEntryUpdateDateParam()
+        assert.is_not_nil(date_str)
+        assert.matches("^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$", date_str)
+    end)
+
+    it("does not write the legacy '+00:00' millisecond format", function()
+        local timestamp = os.time({ year = 2025, month = 11, day = 8, hour = 15, min = 30, sec = 45 })
+
+        KoboStateWriter.write("/fake/db.sqlite", "test_book_1", 35, timestamp, "reading")
+
+        local date_str = findMainEntryUpdateDateParam()
+        assert.is_not_nil(date_str)
+        assert.is_nil(date_str:match("%+00:00"))
+        assert.is_nil(date_str:match("%."))
+    end)
+
+    it("writes an empty DateLastRead when the timestamp is invalid", function()
+        KoboStateWriter.write("/fake/db.sqlite", "test_book_1", 35, 0, "reading")
+
+        local date_str = findMainEntryUpdateDateParam()
+        assert.equals("", date_str)
+    end)
+end)

--- a/spec/reading_state_sync_spec.lua
+++ b/spec/reading_state_sync_spec.lua
@@ -246,6 +246,9 @@ describe("ReadingStateSync", function()
                         { file = "/tmp/.kobo/kepub/0N395DCCSFPF2", time = 1762628755 },
                         { file = "/home/user/Documents/book.epub", time = 1762600000 },
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -288,6 +291,9 @@ describe("ReadingStateSync", function()
                         { file = "/tmp/.kobo/kepub/0N395DCCSFPF2", time = 1762628755 },
                         { file = "/home/user/Documents/other.epub", time = 1762600000 },
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -580,6 +586,9 @@ describe("ReadingStateSync", function()
                     hist = {
                         { file = "/tmp/.kobo/kepub/finished_book", time = 1762600000 },
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -609,6 +618,9 @@ describe("ReadingStateSync", function()
                     hist = {
                         { file = "/tmp/.kobo/kepub/test_book_1", time = 1762700000 },
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -638,6 +650,9 @@ describe("ReadingStateSync", function()
                     hist = {
                         { file = "/tmp/.kobo/kepub/almost_finished", time = 1762700000 },
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -923,6 +938,9 @@ describe("ReadingStateSync", function()
                     hist = {
                         { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762600000 }, -- older
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -977,6 +995,9 @@ describe("ReadingStateSync", function()
                     hist = {
                         { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762700000 }, -- more recent
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1058,6 +1079,9 @@ describe("ReadingStateSync", function()
                     hist = {
                         { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
                     },
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1125,6 +1149,9 @@ describe("ReadingStateSync", function()
             package.preload["readhistory"] = function()
                 return {
                     hist = {}, -- Empty history - book was never opened in KOReader
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1175,6 +1202,9 @@ describe("ReadingStateSync", function()
             package.preload["readhistory"] = function()
                 return {
                     hist = {},
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1234,6 +1264,9 @@ describe("ReadingStateSync", function()
                         hist = {
                             { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762878197 }, -- Newer timestamp
                         },
+                        addItem = function(self, file, ts)
+                            table.insert(self.hist, { file = file, time = ts })
+                        end,
                         addRecord = function(self, record)
                             table.insert(self.hist, record)
                         end,
@@ -1298,6 +1331,9 @@ describe("ReadingStateSync", function()
             package.preload["readhistory"] = function()
                 return {
                     hist = {},
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1361,6 +1397,9 @@ describe("ReadingStateSync", function()
             package.preload["readhistory"] = function()
                 return {
                     hist = {},
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1430,6 +1469,9 @@ describe("ReadingStateSync", function()
             package.preload["readhistory"] = function()
                 return {
                     hist = {},
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,
@@ -1483,6 +1525,9 @@ describe("ReadingStateSync", function()
             package.preload["readhistory"] = function()
                 return {
                     hist = {},
+                    addItem = function(self, file, ts)
+                        table.insert(self.hist, { file = file, time = ts })
+                    end,
                     addRecord = function(self, record)
                         table.insert(self.hist, record)
                     end,

--- a/spec/reading_state_sync_spec.lua
+++ b/spec/reading_state_sync_spec.lua
@@ -1,7 +1,7 @@
 -- Tests for ReadingStateSync module
 
 describe("ReadingStateSync", function()
-    local ReadingStateSync, MetadataParser, createMockDocSettings
+    local ReadingStateSync, MetadataParser, createMockDocSettings, createMockReadHistory
     local SYNC_DIRECTION = { PROMPT = 1, SILENT = 2, NEVER = 3 }
 
     -- Helper function to set up plugin with default granular settings
@@ -23,6 +23,7 @@ describe("ReadingStateSync", function()
         -- Mocks are set up by helper.lua
         local helper = require("spec/helper")
         createMockDocSettings = helper.createMockDocSettings
+        createMockReadHistory = helper.createMockReadHistory
         ReadingStateSync = require("src/reading_state_sync")
         MetadataParser = require("src/metadata_parser")
     end)
@@ -240,19 +241,11 @@ describe("ReadingStateSync", function()
 
             -- Update ReadHistory mock to have specific test entries
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
-                        { file = "/tmp/.kobo/kepub/0N395DCCSFPF2", time = 1762628755 },
-                        { file = "/home/user/Documents/book.epub", time = 1762600000 },
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
+                    { file = "/tmp/.kobo/kepub/0N395DCCSFPF2", time = 1762628755 },
+                    { file = "/home/user/Documents/book.epub", time = 1762600000 },
+                })
             end
 
             -- Reload to get updated mock
@@ -285,19 +278,11 @@ describe("ReadingStateSync", function()
 
             -- Update ReadHistory mock with Kobo paths
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
-                        { file = "/tmp/.kobo/kepub/0N395DCCSFPF2", time = 1762628755 },
-                        { file = "/home/user/Documents/other.epub", time = 1762600000 },
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
+                    { file = "/tmp/.kobo/kepub/0N395DCCSFPF2", time = 1762628755 },
+                    { file = "/home/user/Documents/other.epub", time = 1762600000 },
+                })
             end
 
             -- Reload to get updated mock
@@ -582,17 +567,9 @@ describe("ReadingStateSync", function()
             setupPluginSettings(sync)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/finished_book", time = 1762600000 },
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/finished_book", time = 1762600000 },
+                })
             end
 
             package.loaded["readhistory"] = nil
@@ -614,17 +591,9 @@ describe("ReadingStateSync", function()
             setupPluginSettings(sync)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/test_book_1", time = 1762700000 },
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/test_book_1", time = 1762700000 },
+                })
             end
 
             package.loaded["readhistory"] = nil
@@ -646,17 +615,9 @@ describe("ReadingStateSync", function()
             setupPluginSettings(sync)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/almost_finished", time = 1762700000 },
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/almost_finished", time = 1762700000 },
+                })
             end
 
             package.loaded["readhistory"] = nil
@@ -934,17 +895,9 @@ describe("ReadingStateSync", function()
 
             -- Update ReadHistory mock
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762600000 }, -- older
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762600000 }, -- older
+                })
             end
 
             package.loaded["readhistory"] = nil
@@ -991,17 +944,9 @@ describe("ReadingStateSync", function()
 
             -- Update ReadHistory mock with newer KOReader timestamp
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762700000 }, -- more recent
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762700000 }, -- more recent
+                })
             end
 
             package.loaded["readhistory"] = nil
@@ -1075,17 +1020,9 @@ describe("ReadingStateSync", function()
 
             -- Update ReadHistory with test data
             package.preload["readhistory"] = function()
-                return {
-                    hist = {
-                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
-                    },
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762685677 },
+                })
             end
 
             package.loaded["readhistory"] = nil
@@ -1147,15 +1084,7 @@ describe("ReadingStateSync", function()
 
             -- Mock ReadHistory with NO entry for this book
             package.preload["readhistory"] = function()
-                return {
-                    hist = {}, -- Empty history - book was never opened in KOReader
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({}) -- Empty history - book was never opened in KOReader
             end
 
             package.loaded["readhistory"] = nil
@@ -1200,15 +1129,7 @@ describe("ReadingStateSync", function()
             sync:setEnabled(true)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {},
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({})
             end
 
             package.loaded["readhistory"] = nil
@@ -1260,17 +1181,9 @@ describe("ReadingStateSync", function()
 
                 -- Mock ReadHistory with newer timestamp than Kobo
                 package.preload["readhistory"] = function()
-                    return {
-                        hist = {
-                            { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762878197 }, -- Newer timestamp
-                        },
-                        addItem = function(self, file, ts)
-                            table.insert(self.hist, { file = file, time = ts })
-                        end,
-                        addRecord = function(self, record)
-                            table.insert(self.hist, record)
-                        end,
-                    }
+                    return createMockReadHistory({
+                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762878197 }, -- Newer timestamp
+                    })
                 end
 
                 package.loaded["readhistory"] = nil
@@ -1329,15 +1242,7 @@ describe("ReadingStateSync", function()
             sync:setEnabled(true)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {},
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({})
             end
 
             package.loaded["readhistory"] = nil
@@ -1395,15 +1300,7 @@ describe("ReadingStateSync", function()
             setupPluginSettings(sync)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {},
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({})
             end
 
             package.loaded["readhistory"] = nil
@@ -1467,15 +1364,7 @@ describe("ReadingStateSync", function()
             setupPluginSettings(sync) -- Use helper function
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {},
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({})
             end
 
             package.loaded["readhistory"] = nil
@@ -1523,15 +1412,7 @@ describe("ReadingStateSync", function()
             setupPluginSettings(sync)
 
             package.preload["readhistory"] = function()
-                return {
-                    hist = {},
-                    addItem = function(self, file, ts)
-                        table.insert(self.hist, { file = file, time = ts })
-                    end,
-                    addRecord = function(self, record)
-                        table.insert(self.hist, record)
-                    end,
-                }
+                return createMockReadHistory({})
             end
 
             package.loaded["readhistory"] = nil
@@ -1564,6 +1445,202 @@ describe("ReadingStateSync", function()
             -- Should sync the 16% from main book entry
             assert.equals(0.16, mock_doc_settings:readSetting("percent_finished"))
             assert.equals(1, query_count) -- Should only query once for the main entry
+
+            sync.readKoboState = original_readKoboState
+        end)
+    end)
+
+    describe("timestamp propagation between KOReader and Kobo", function()
+        it("should push the KOReader timestamp (not the current time) when PUSH scenario runs", function()
+            local kr_recorded_time = 1762700000 -- Some time in the past
+
+            package.preload["readhistory"] = function()
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = kr_recorded_time },
+                })
+            end
+
+            package.loaded["readhistory"] = nil
+            require("readhistory")
+
+            package.loaded["src/reading_state_sync"] = nil
+            local FreshReadingStateSync = require("src/reading_state_sync")
+
+            local parser = MetadataParser:new()
+            local sync = FreshReadingStateSync:new(parser)
+            sync:setEnabled(true)
+            setupPluginSettings(sync)
+
+            local mock_doc_settings = createMockDocSettings("/tmp/.kobo/kepub/0N3773Z7HFPXB", {
+                percent_finished = 0.75,
+                summary = { status = "reading" },
+            })
+
+            local original_readKoboState = sync.readKoboState
+            sync.readKoboState = function(self, book_id)
+                return {
+                    percent_read = 50,
+                    timestamp = 1762600000, -- older than KOReader
+                    status = "reading",
+                    kobo_status = 1,
+                }
+            end
+
+            local written_timestamp = nil
+            local original_writeKoboState = sync.writeKoboState
+            sync.writeKoboState = function(self, book_id, percent_read, timestamp, status)
+                written_timestamp = timestamp
+                return true
+            end
+
+            local result = sync:syncBidirectional("0N3773Z7HFPXB", mock_doc_settings)
+
+            assert.is_true(result)
+            assert.equals(kr_recorded_time, written_timestamp)
+            assert.is_not.equals(os.time(), written_timestamp)
+
+            sync.readKoboState = original_readKoboState
+            sync.writeKoboState = original_writeKoboState
+        end)
+
+        it("should update ReadHistory with the Kobo timestamp after a PULL sync (exact path match)", function()
+            package.preload["readhistory"] = function()
+                return createMockReadHistory({
+                    { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762600000 }, -- older
+                })
+            end
+
+            package.loaded["readhistory"] = nil
+            local ReadHistory = require("readhistory")
+
+            package.loaded["src/reading_state_sync"] = nil
+            local FreshReadingStateSync = require("src/reading_state_sync")
+
+            local parser = MetadataParser:new()
+            local sync = FreshReadingStateSync:new(parser)
+            sync:setEnabled(true)
+            setupPluginSettings(sync)
+
+            local mock_doc_settings = createMockDocSettings("/tmp/.kobo/kepub/0N3773Z7HFPXB", {
+                percent_finished = 0.5,
+                summary = { status = "reading" },
+            })
+
+            local original_readKoboState = sync.readKoboState
+            sync.readKoboState = function(self, book_id)
+                return {
+                    percent_read = 75,
+                    timestamp = 1762700000, -- more recent than KOReader
+                    status = "reading",
+                    kobo_status = 1,
+                }
+            end
+
+            local result = sync:syncBidirectional("0N3773Z7HFPXB", mock_doc_settings)
+
+            assert.is_true(result)
+
+            -- addItem should update the existing entry in place (dedup + move to
+            -- front), not append a duplicate.
+            assert.equals(1, #ReadHistory.hist)
+            assert.equals("/tmp/.kobo/kepub/0N3773Z7HFPXB", ReadHistory.hist[1].file)
+            assert.equals(1762700000, ReadHistory.hist[1].time)
+
+            sync.readKoboState = original_readKoboState
+        end)
+
+        it(
+            "should update ReadHistory with the Kobo timestamp after a PULL sync (virtual path / book ID match)",
+            function()
+                package.preload["readhistory"] = function()
+                    return createMockReadHistory({
+                        { file = "/tmp/.kobo/kepub/0N3773Z7HFPXB", time = 1762600000 }, -- older
+                    })
+                end
+
+                package.loaded["readhistory"] = nil
+                local ReadHistory = require("readhistory")
+
+                package.loaded["src/reading_state_sync"] = nil
+                local FreshReadingStateSync = require("src/reading_state_sync")
+
+                local parser = MetadataParser:new()
+                local sync = FreshReadingStateSync:new(parser)
+                sync:setEnabled(true)
+                setupPluginSettings(sync)
+
+                local mock_doc_settings = createMockDocSettings("KOBO_VIRTUAL://0N3773Z7HFPXB/Test Book.epub", {
+                    percent_finished = 0.5,
+                    summary = { status = "reading" },
+                })
+
+                local original_readKoboState = sync.readKoboState
+                sync.readKoboState = function(self, book_id)
+                    return {
+                        percent_read = 75,
+                        timestamp = 1762700000, -- more recent than KOReader
+                        status = "reading",
+                        kobo_status = 1,
+                    }
+                end
+
+                local result = sync:syncBidirectional("0N3773Z7HFPXB", mock_doc_settings)
+
+                assert.is_true(result)
+
+                -- addItem should update the existing entry in place (dedup + move
+                -- to front), not append a duplicate. The entry's file stays the
+                -- real Kobo path (from the matched history entry), not the
+                -- virtual doc_path used to look it up.
+                assert.equals(1, #ReadHistory.hist)
+                assert.equals("/tmp/.kobo/kepub/0N3773Z7HFPXB", ReadHistory.hist[1].file)
+                assert.equals(1762700000, ReadHistory.hist[1].time)
+
+                sync.readKoboState = original_readKoboState
+            end
+        )
+
+        it("should not crash a PULL sync when doc_path is nil", function()
+            local parser = MetadataParser:new()
+            local sync = ReadingStateSync:new(parser)
+            sync:setEnabled(true)
+            setupPluginSettings(sync)
+
+            local saved_settings = {}
+            local mock_doc_settings = {
+                data = {}, -- No doc_path
+                readSetting = function(self, key)
+                    if key == "percent_finished" then
+                        return 0
+                    end
+                    if key == "summary" then
+                        return { status = "abandoned" }
+                    end
+                    return nil
+                end,
+                saveSetting = function(self, key, value)
+                    saved_settings[key] = value
+                end,
+                flush = function(self) end,
+            }
+
+            local original_readKoboState = sync.readKoboState
+            sync.readKoboState = function(self, book_id)
+                return {
+                    percent_read = 50,
+                    timestamp = 1762700000,
+                    status = "reading",
+                    kobo_status = 1,
+                }
+            end
+
+            local ok, result = pcall(function()
+                return sync:syncBidirectional("0N3773Z7HFPXB", mock_doc_settings)
+            end)
+
+            assert.is_true(ok)
+            assert.is_true(result)
+            assert.equals(0.5, saved_settings["percent_finished"])
 
             sync.readKoboState = original_readKoboState
         end)

--- a/src/lib/kobo_state_reader.lua
+++ b/src/lib/kobo_state_reader.lua
@@ -9,8 +9,48 @@ local logger = require("logger")
 local KoboStateReader = {}
 
 ---
+--- Returns the local timezone offset (local - UTC) in seconds.
+---
+--- This function uses os.date's "*t" and "!*t" formats
+--- (see more [here](https://www.lua.org/manual/5.4/manual.html#pdf-os.date))
+--- to calculate the difference between local time and UTC for a given timestamp.
+---
+--- Due to the way os.time works, this function has to override the isdst field to false to avoid
+--- incorrect offsets during daylight saving time. This is because os.time will interpret the isdst
+--- field and adjust the time accordingly, which will give always the standard offset regardless of whether
+--- the timestamp is in DST or not. With isdst set to false, os.time will treat the time as standard time,
+--- and the difference between local and UTC will be the actual offset for that timestamp, which is what we want.
+--- @param ts number|nil: Optional timestamp to calculate offset for. Defaults to current time.
+--- @return number: Local timezone offset (local - UTC) in seconds.
+local function localUtcOffset(ts)
+    ts = ts or os.time()
+
+    local local_dt = os.date("*t", ts) --[[@as osdate]]
+    local utc_dt = os.date("!*t", ts) --[[@as osdate]]
+
+    local_dt.isdst = false
+    utc_dt.isdst = false
+
+    return os.difftime(os.time(local_dt), os.time(utc_dt))
+end
+
+---
+--- Converts a timestamp interpreted in a source timezone into a local timestamp.
+--- @param ts number: Timestamp obtained by interpreting the datetime as local time.
+--- @param local_offset number: Local timezone offset (local - UTC) in seconds.
+--- @param tz_offset number|nil: Timezone offset from the ISO 8601 suffix (+HH:MM or -HH:MM), in seconds. Defaults to 0 (UTC).
+--- @return number: Timestamp representing the same instant in local time.
+local function toLocalTimestamp(ts, local_offset, tz_offset)
+    return ts - (tz_offset or 0) + local_offset
+end
+
+---
 --- Parses ISO 8601 datetime string to Unix timestamp.
---- Handles formats: YYYY-MM-DDTHH:MM:SSZ and YYYY-MM-DD HH:MM:SS.SSS+00:00
+--- Handles formats:
+---     YYYY-MM-DDTHH:MM:SS
+---     YYYY-MM-DDTHH:MM:SSZ
+---     YYYY-MM-DD HH:MM:SS.SSS+00:00
+--- Datetimes without a timezone are interpreted as local time.
 --- @param date_string string: ISO 8601 datetime string.
 --- @return number: Unix timestamp, or 0 if parsing fails.
 local function parseKoboTimestamp(date_string)
@@ -18,7 +58,7 @@ local function parseKoboTimestamp(date_string)
         return 0
     end
 
-    local year, month, day, hour, min, sec = date_string:match("(%d+)-(%d+)-(%d+)[T ](%d+):(%d+):(%d+)")
+    local _, end_pos, year, month, day, hour, min, sec = date_string:find("(%d+)-(%d+)-(%d+)[T ](%d+):(%d+):(%d+)")
     if not year then
         return 0
     end
@@ -32,7 +72,32 @@ local function parseKoboTimestamp(date_string)
         sec = tonumber(sec),
     })
 
-    return dt or 0
+    if not dt then
+        return 0
+    end
+
+    local remainder = date_string:sub(end_pos + 1):gsub("^%.%d+", "")
+
+    if remainder == "" then
+        return dt
+    end
+
+    local local_offset = localUtcOffset(dt)
+
+    if remainder == "Z" then
+        return toLocalTimestamp(dt, local_offset)
+    end
+
+    local sign, hour_offset, min_offset = remainder:match("^([+-])(%d+):(%d+)$")
+    if sign then
+        local tz_offset = tonumber(hour_offset) * 3600 + tonumber(min_offset) * 60
+        if sign == "-" then
+            tz_offset = -tz_offset
+        end
+        return toLocalTimestamp(dt, local_offset, tz_offset)
+    end
+
+    return dt
 end
 
 ---

--- a/src/lib/kobo_state_writer.lua
+++ b/src/lib/kobo_state_writer.lua
@@ -17,7 +17,7 @@ local function formatKoboTimestamp(timestamp)
         return ""
     end
 
-    return os.date("!%Y-%m-%d %H:%M:%S.000+00:00", timestamp)
+    return os.date("!%Y-%m-%dT%H:%M:%SZ", timestamp) --[[@as string]]
 end
 
 ---

--- a/src/reading_state_sync.lua
+++ b/src/reading_state_sync.lua
@@ -514,7 +514,7 @@ function ReadingStateSync:executePushToKobo(book_id, doc_settings, kobo_state, k
     self:syncIfApproved(false, true, function()
         local summary = doc_settings:readSetting("summary") or {}
         local kr_status = summary.status or "reading"
-        local current_timestamp = os.time()
+        local current_timestamp = kr_timestamp
 
         logger.info("KoboPlugin: Syncing TO Kobo (PUSH) - applying newer KOReader state to Kobo")
         self:writeKoboState(book_id, kr_percent * 100, current_timestamp, kr_status)

--- a/src/reading_state_sync.lua
+++ b/src/reading_state_sync.lua
@@ -411,6 +411,40 @@ local function getValidatedKOReaderTimestamp(doc_path)
 end
 
 ---
+--- Persists KOReader timestamp to ReadHistory for a document.
+--- @param doc_path string: Document path.
+--- @param timestamp number: Timestamp to persist.
+--- @return boolean: True if timestamp was persisted, false if no matching entry found.
+local function persistKOReaderTimestamp(doc_path, timestamp)
+    logger.dbg("KoboPlugin: Persisting timestamp for doc_path in ReadHistory:", doc_path)
+    local book_id_from_virtual = extractBookIdFromVirtualPath(doc_path)
+
+    for _, entry in ipairs(ReadHistory.hist) do
+        if not entry.file then
+            goto continue
+        end
+
+        logger.dbg("KoboPlugin: Comparing with history entry:", entry.file)
+
+        if entry.file == doc_path then
+            logger.dbg("KoboPlugin: Found matching history entry (exact path) with timestamp:", timestamp)
+            ReadHistory:addItem(entry.file, timestamp)
+            return true
+        end
+
+        if book_id_from_virtual and entry.file:match(book_id_from_virtual) then
+            logger.dbg("KoboPlugin: Found matching history entry (book ID match) with timestamp:", timestamp)
+            ReadHistory:addItem(entry.file, timestamp)
+            return true
+        end
+
+        ::continue::
+    end
+
+    return false
+end
+
+---
 --- Executes sync FROM Kobo to KOReader (PULL scenario).
 --- @param book_id string: Book ContentID.
 --- @param doc_settings table: Document settings instance.
@@ -463,6 +497,12 @@ function ReadingStateSync:executePullFromKobo(book_id, doc_settings, kobo_state,
         end
 
         doc_settings:saveSetting("summary", summary)
+        local doc_path = doc_settings.data and doc_settings.data.doc_path
+        if doc_path then
+            persistKOReaderTimestamp(doc_path, kobo_state.timestamp)
+        else
+            logger.warn("KoboPlugin: doc_path is nil, cannot persist KOReader timestamp")
+        end
         doc_settings:flush()
 
         sync_completed = true


### PR DESCRIPTION
Closes #204

## Summary
The differences between KOReader local time and Kobo UTC time wasn't taken into account.
This PR fixes it by switching to local time always before converting a time string into a timestamp.

Also fixes the Kobo time not being synchronised to KOReader `ReadHistory`.

## Test Plan
- [x] Added unit tests in `spec/reading_state_sync_spec.lua` asserting that:
  - [x] `ReadHistory` is correctly modified after PULL synchronisation.
- [x] Added unit tests in `spec/kobo_state_reader_spec.lua` asserting that:
  - [x] `readTimestamp` returns the expected output.
- [x] Added unit tests in `spec/kobo_state_writer_spec.lua` asserting that:
  - [x] modified `entry.time` after write is in the expected format.
- Verified on device (Kobo, KOReader v2026.03, kobo.koplugin 0.4.1):
  - [x] Kobo database contains the correct date after sync.
  - [x] `ReadHistory` is written and books are ordered correctly after sync.
  - [x] Chaining synchronisations no longer syncs the same books multiple times.
