### PR TITLE
fix(bluetooth): recover input handlers and monitoring after resume on slow MTK stack startup

### DIFF
--- a/src/kobo_bluetooth.lua
+++ b/src/kobo_bluetooth.lua
@@ -47,6 +47,8 @@ local KoboBluetooth = InputContainer:extend({
     is_discovery_active = false,
     is_auto_detection_active = false,
     is_auto_connect_active = false,
+    enable_retry_task = nil,
+    reopen_watchdog_task = nil,
 })
 
 ---
@@ -75,6 +77,14 @@ function KoboBluetooth:_cleanup(broadcast_refresh)
     if self.key_bindings then
         self.key_bindings:stopPolling()
     end
+
+    -- Stop pending enable-retry and reopen-watchdog tasks
+    if self.enable_retry_task then
+        UIManager:unschedule(self.enable_retry_task)
+        self.enable_retry_task = nil
+    end
+
+    self:_stopReopenWatchdog()
 
     -- Stop auto-detection and auto-connect
     self:stopAutoDetectionPolling(broadcast_refresh)
@@ -476,15 +486,16 @@ function KoboBluetooth:_pollForBluetoothEnabledAndRestoreWifi(
 
     if not self:isBluetoothEnabled() then
         if poll_count >= max_polls then
-            logger.warn("KoboBluetooth: Timeout waiting for Bluetooth to enable")
+            -- The initial fast poll window (typically 3 s) elapsed without the
+            -- adapter reporting Powered=true. On MTK devices the bluedroid
+            -- stack can take much longer to come up after resume (WiFi
+            -- firmware load, service startup), so instead of giving up --
+            -- which previously left Bluetooth physically on but with no
+            -- monitoring and no input handlers, i.e. "connected but page
+            -- turner does nothing" -- enter a slower extended retry loop.
+            logger.warn("KoboBluetooth: Initial poll window elapsed, entering extended enable retry loop")
 
-            if self.bluetooth_standby_prevented then
-                logger.dbg("KoboBluetooth: Bluetooth enable failed, allowing standby")
-                UIManager:allowStandby()
-                self.bluetooth_standby_prevented = false
-            end
-
-            self:_restoreWifiState(is_resume, initial_wifi_was_on)
+            self:_scheduleEnableRetry(1, is_resume, initial_wifi_was_on, on_complete)
 
             return
         end
@@ -505,6 +516,20 @@ function KoboBluetooth:_pollForBluetoothEnabledAndRestoreWifi(
         return
     end
 
+    self:_onBluetoothEnabled(is_resume, initial_wifi_was_on, on_complete)
+end
+
+---
+--- Executes the full startup sequence once Bluetooth is confirmed enabled.
+--- Starts monitoring, auto-detection/auto-connect, and opens input devices for
+--- already-connected paired devices. Also starts a short-lived watchdog that
+--- re-opens input handlers for devices reconnecting slightly later (common
+--- after resume on MTK devices, where the bluedroid stack needs time to come
+--- up and Connected signals can be emitted before monitoring is in place).
+--- @param is_resume boolean True if called from resume context
+--- @param initial_wifi_was_on boolean Whether WiFi was on before Bluetooth enable
+--- @param on_complete function Optional callback to run after startup
+function KoboBluetooth:_onBluetoothEnabled(is_resume, initial_wifi_was_on, on_complete)
     logger.info("KoboBluetooth: Bluetooth enabled, starting processes")
 
     if not self.bluetooth_standby_prevented then
@@ -518,9 +543,161 @@ function KoboBluetooth:_pollForBluetoothEnabledAndRestoreWifi(
 
     self:_restoreWifiState(is_resume, initial_wifi_was_on)
 
+    -- Page turners may reconnect seconds after the adapter reports on; the
+    -- watchdog re-opens their input handlers even if the D-Bus Connected
+    -- signal was missed.
+    self:_startReopenWatchdog()
+
     if on_complete then
         logger.dbg("KoboBluetooth: executing on_complete callback")
         on_complete()
+    end
+end
+
+---
+--- Keeps waiting for Bluetooth to become enabled after the initial fast poll
+--- window timed out. Retries every RETRY_INTERVAL seconds, up to MAX_RETRIES
+--- times, before giving up. On success the full startup sequence runs, so a
+--- slow bluedroid startup after resume no longer leaves the plugin with
+--- Bluetooth physically on but without monitoring or input handlers.
+--- @param attempt number Current retry attempt (1-based)
+--- @param is_resume boolean True if called from resume context
+--- @param initial_wifi_was_on boolean Whether WiFi was on before Bluetooth enable
+--- @param on_complete function Optional callback executed once Bluetooth is enabled
+function KoboBluetooth:_scheduleEnableRetry(attempt, is_resume, initial_wifi_was_on, on_complete)
+    local RETRY_INTERVAL = 2
+    local MAX_RETRIES = 15
+
+    if attempt > MAX_RETRIES then
+        logger.warn("KoboBluetooth: Giving up waiting for Bluetooth to enable after", MAX_RETRIES, "retries")
+
+        if self.bluetooth_standby_prevented then
+            logger.dbg("KoboBluetooth: Bluetooth enable failed, allowing standby")
+            UIManager:allowStandby()
+            self.bluetooth_standby_prevented = false
+        end
+
+        self:_restoreWifiState(is_resume, initial_wifi_was_on)
+
+        return
+    end
+
+    logger.dbg("KoboBluetooth: scheduling enable retry", attempt)
+
+    self.enable_retry_task = function()
+        self.enable_retry_task = nil
+
+        if self:isBluetoothEnabled() then
+            logger.info("KoboBluetooth: Bluetooth enabled after", attempt, "extended retries")
+            self:_onBluetoothEnabled(is_resume, initial_wifi_was_on, on_complete)
+
+            return
+        end
+
+        self:_scheduleEnableRetry(attempt + 1, is_resume, initial_wifi_was_on, on_complete)
+    end
+
+    UIManager:scheduleIn(RETRY_INTERVAL, self.enable_retry_task)
+end
+
+---
+--- Ensures all Bluetooth processes (monitoring, auto-detection, input
+--- handlers) are running when the adapter is already enabled. Used when
+--- turn-on is invoked while Bluetooth is already on -- e.g. a suspend-time
+--- turn-off failed, leaving the hardware on but the processes torn down --
+--- which previously produced "connected but page turner does nothing".
+--- Safe to call when processes are already running: all steps are idempotent.
+--- @param reason string Log context for why this was invoked
+function KoboBluetooth:_ensureProcessesRunning(reason)
+    if not self:isBluetoothEnabled() then
+        return
+    end
+
+    logger.info("KoboBluetooth: Ensuring Bluetooth processes are running (", reason, ")")
+
+    self:_startBluetoothProcesses()
+    self.input_handler:autoOpenConnectedDevices(self.device_manager:getDevices())
+    self:_startReopenWatchdog()
+end
+
+---
+--- Starts a short-lived watchdog that periodically re-opens input handlers for
+--- devices that are connected at the Bluetooth layer but have no open input
+--- reader. Covers cases where the D-Bus Connected signal was missed (monitor
+--- restart races, signals emitted while the stack was still starting, devices
+--- reconnecting right at resume). Stops early once every connected device has
+--- a live reader.
+--- @param max_attempts number Optional maximum number of checks (default: 15)
+function KoboBluetooth:_startReopenWatchdog(max_attempts)
+    local WATCHDOG_INTERVAL = 2
+    max_attempts = max_attempts or 15
+
+    self:_stopReopenWatchdog()
+
+    if not self.input_handler or not self.device_manager then
+        return
+    end
+
+    local attempts = 0
+
+    local function tick()
+        self.reopen_watchdog_task = nil
+        attempts = attempts + 1
+
+        if not self:isBluetoothEnabled() then
+            logger.dbg("KoboBluetooth: Reopen watchdog stopping - Bluetooth is off")
+
+            return
+        end
+
+        self.device_manager:loadDevices()
+
+        local any_connected = false
+        local pending_reopen = 0
+
+        for _, device in ipairs(self.device_manager:getDevices()) do
+            if device.connected then
+                any_connected = true
+
+                local reader = self.input_handler:getIsolatedReader(device.address)
+
+                if not (reader and reader:isOpen()) then
+                    pending_reopen = pending_reopen + 1
+
+                    local label = device.name and device.name ~= "" and device.name or device.address
+
+                    logger.info("KoboBluetooth: Reopen watchdog re-opening input for", label)
+                    self.input_handler:openIsolatedInputDevice(device, false, false)
+                end
+            end
+        end
+
+        if any_connected and pending_reopen == 0 then
+            logger.info("KoboBluetooth: Reopen watchdog done - all connected devices have readers")
+
+            return
+        end
+
+        if attempts >= max_attempts then
+            logger.dbg("KoboBluetooth: Reopen watchdog stopped after", attempts, "attempts")
+
+            return
+        end
+
+        self.reopen_watchdog_task = tick
+        UIManager:scheduleIn(WATCHDOG_INTERVAL, tick)
+    end
+
+    self.reopen_watchdog_task = tick
+    UIManager:scheduleIn(WATCHDOG_INTERVAL, tick)
+end
+
+---
+--- Stops the reopen watchdog if it is running.
+function KoboBluetooth:_stopReopenWatchdog()
+    if self.reopen_watchdog_task then
+        UIManager:unschedule(self.reopen_watchdog_task)
+        self.reopen_watchdog_task = nil
     end
 end
 

--- a/src/lib/bluetooth/implementations/libra2_bluetooth.lua
+++ b/src/lib/bluetooth/implementations/libra2_bluetooth.lua
@@ -44,6 +44,10 @@ function Libra2Bluetooth:turnBluetoothOn(is_resume, on_complete)
     if self:isBluetoothEnabled() then
         logger.warn("Libra2Bluetooth: turn on Bluetooth was called while already on.")
 
+        -- The adapter is already on, but a previous suspend may have torn down
+        -- monitoring/input handlers. Make sure everything is running again.
+        self:_ensureProcessesRunning("turn on while already enabled")
+
         return
     end
 
@@ -72,7 +76,10 @@ function Libra2Bluetooth:turnBluetoothOn(is_resume, on_complete)
     }))
 
     self:emitBluetoothStateChangedEvent(true)
-    self:_startBluetoothProcesses()
+
+    -- Starts processes, auto-opens input devices for already-connected devices,
+    -- and arms the reopen watchdog for late reconnects.
+    self:_ensureProcessesRunning("turn on")
 
     if on_complete then
         on_complete()

--- a/src/lib/bluetooth/implementations/mtk_bluetooth.lua
+++ b/src/lib/bluetooth/implementations/mtk_bluetooth.lua
@@ -48,6 +48,11 @@ function MTKBluetooth:turnBluetoothOn(is_resume, on_complete)
     if self:isBluetoothEnabled() then
         logger.warn("MTKBluetooth: turn on Bluetooth was called while already on.")
 
+        -- The adapter is already on, but a previous suspend may have torn down
+        -- monitoring/input handlers (e.g. the suspend-time turn-off failed).
+        -- Make sure everything is running again instead of silently returning.
+        self:_ensureProcessesRunning("turn on while already enabled")
+
         return
     end
 

--- a/src/lib/bluetooth/input_device_handler.lua
+++ b/src/lib/bluetooth/input_device_handler.lua
@@ -326,6 +326,18 @@ function InputDeviceHandler:openIsolatedInputDevice(device_info, show_messages, 
         show_messages = true
     end
 
+    -- Idempotency guard: if a live reader already exists for this device,
+    -- input handling is already set up (e.g. auto-detection fired just before
+    -- the post-resume watchdog ran). Opening a second fd for the same device
+    -- would leak the old one and duplicate key events.
+    local existing = self.isolated_readers[device_info.address]
+
+    if existing and existing.reader:isOpen() then
+        logger.dbg("InputDeviceHandler: Reader already open for", device_info.address, "- skipping")
+
+        return true
+    end
+
     local detected_path
 
     if device_info.name then


### PR DESCRIPTION
## Problem
After suspend/resume, the Bluetooth page turner reconnects (shows as
connected), but KOReader no longer receives key events. Restarting KOReader
is the only way to recover. Reproduced on Kobo Clara BW (MTK) with a
KeyKeyMini page turner. Matches #44.

## Root causes
1. After resume, `_pollForBluetoothEnabledAndRestoreWifi` only waits
   30 × 100 ms = 3 s for the adapter to report Powered=true. On MTK devices
   the bluedroid stack often takes longer (WiFi firmware load, service
   startup). On timeout the plugin silently gave up: no D-Bus monitoring, no
   auto-detection, no input handlers — while the hardware still came up and
   the device reconnected, producing "connected but page turner dead".
2. `turnBluetoothOn` early-returned when the adapter was already on (e.g. a
   suspend-time turn-off failed), without restoring the processes torn down
   by the suspend cleanup.
3. If the Connected D-Bus signal fired while monitoring was restarting, it
   was lost forever with no fallback.

## Fix
- On initial poll timeout, enter an extended retry loop (every 2 s, up to
  15 retries) instead of giving up; full startup runs once the adapter is up.
- New `_ensureProcessesRunning()` used by the already-on branch of
  `turnBluetoothOn` (MTK and Libra 2).
- New short-lived reopen watchdog: for ~30 s after Bluetooth is up,
  re-opens input handlers for devices that are connected but have no live
  reader, covering missed D-Bus signals.
- `openIsolatedInputDevice` is now idempotent, so the watchdog and
  auto-detection cannot double-open a device (fd leak / duplicate events).

## Testing
- On-device: Kobo Clara BW + KeyKeyMini, KOReader v2026.07.2 — page turning
  works again after sleep/wake without restarting KOReader.
- Logic verified with a mock-KOReader simulation harness (19 assertions,
  covering slow enable, lost Connected signal, failed suspend-time turn-off,
  and final give-up paths).

Closes #44