### PR TITLE
fix(bluetooth): stop leaking 20Hz input poll tasks (#229)

### DIFF
--- a/spec/bluetooth_keybindings_spec.lua
+++ b/spec/bluetooth_keybindings_spec.lua
@@ -1048,4 +1048,78 @@ describe("BluetoothKeyBindings", function()
             end)
         end)
     end)
+
+    describe("input polling task tracking", function()
+        local UIManager
+        local original_scheduleIn
+        local original_unschedule
+        local scheduled
+
+        local function installKoreaderLikeScheduler()
+            scheduled = {}
+            UIManager.scheduleIn = function(_, _time, callback)
+                table.insert(scheduled, callback)
+            end
+            UIManager.unschedule = function(_, action)
+                for i = #scheduled, 1, -1 do
+                    if scheduled[i] == action then
+                        table.remove(scheduled, i)
+                    end
+                end
+            end
+        end
+
+        before_each(function()
+            UIManager = require("ui/uimanager")
+            original_scheduleIn = UIManager.scheduleIn
+            original_unschedule = UIManager.unschedule
+            installKoreaderLikeScheduler()
+
+            instance.input_device_handler = {
+                hasIsolatedReaders = function()
+                    return true
+                end,
+                pollIsolatedReaders = function() end,
+            }
+        end)
+
+        after_each(function()
+            UIManager.scheduleIn = original_scheduleIn
+            UIManager.unschedule = original_unschedule
+        end)
+
+        it("should keep a function handle when scheduleIn returns nil", function()
+            instance:startPolling()
+
+            assert.is_function(instance.poll_task)
+            assert.are.equal(1, #scheduled)
+            assert.are.equal(instance.poll_task, scheduled[1])
+        end)
+
+        it("should not start a second loop while already polling", function()
+            instance:startPolling()
+            instance:startPolling()
+
+            assert.are.equal(1, #scheduled)
+        end)
+
+        it("should unschedule the same function on stop", function()
+            instance:startPolling()
+            instance:stopPolling()
+
+            assert.is_nil(instance.poll_task)
+            assert.are.equal(0, #scheduled)
+        end)
+
+        it("should not reschedule after stopPolling during an active tick", function()
+            instance:startPolling()
+
+            local poll = scheduled[1]
+            poll()
+            assert.are.equal(2, #scheduled)
+
+            instance:stopPolling()
+            assert.are.equal(0, #scheduled)
+        end)
+    end)
 end)

--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -1474,8 +1474,15 @@ if not package.preload["ui/uimanager"] then
 
         function UIManager:unschedule(task_id)
             table.insert(self._unschedule_calls, { task_id = task_id })
-            if self._scheduled_tasks then
-                self._scheduled_tasks[task_id] = nil
+            if not self._scheduled_tasks then
+                return
+            end
+
+            self._scheduled_tasks[task_id] = nil
+            for id, task in pairs(self._scheduled_tasks) do
+                if task and task.callback == task_id then
+                    self._scheduled_tasks[id] = nil
+                end
             end
         end
 

--- a/spec/kobo_bluetooth_spec.lua
+++ b/spec/kobo_bluetooth_spec.lua
@@ -279,6 +279,22 @@ describe("KoboBluetooth", function()
                 -- Verify turnBluetoothOff was NOT called (Bluetooth already off)
                 assert.is_false(turnBluetoothOff_called)
             end)
+
+            it("should stop key-binding polling even when Bluetooth is already off", function()
+                setMockPopenOutput("variant boolean false")
+
+                local instance = KoboBluetooth.create()
+                instance:initWithPlugin(mock_plugin)
+
+                local stop_polling_called = false
+                instance.key_bindings.stopPolling = function()
+                    stop_polling_called = true
+                end
+
+                instance:onSuspend()
+
+                assert.is_true(stop_polling_called)
+            end)
         end)
         describe("standby prevention pairing", function()
             it("should pair preventStandby and allowStandby calls correctly", function()

--- a/src/bluetooth_keybindings.lua
+++ b/src/bluetooth_keybindings.lua
@@ -171,6 +171,8 @@ end
 ---
 --- Starts polling for Bluetooth input events.
 --- Should be called when Bluetooth devices are connected.
+--- Additional calls are ignored while a poll callback is already scheduled.
+--- The callback is stored on `poll_task` so `stopPolling` can unschedule it.
 function BluetoothKeyBindings:startPolling()
     if self.poll_task then
         logger.dbg("BluetoothKeyBindings: Already polling, skipping start")
@@ -186,22 +188,29 @@ function BluetoothKeyBindings:startPolling()
 
     logger.info("BluetoothKeyBindings: Starting Bluetooth input polling")
 
-    local function poll()
+    self.poll_task = function()
+        if not self.poll_task then
+            return
+        end
+
         local has_readers = self.input_device_handler:hasIsolatedReaders()
 
         if has_readers then
             self.input_device_handler:pollIsolatedReaders(0)
         end
 
-        self.poll_task = UIManager:scheduleIn(self.poll_interval, poll)
+        if self.poll_task then
+            UIManager:scheduleIn(self.poll_interval, self.poll_task)
+        end
     end
 
-    self.poll_task = UIManager:scheduleIn(self.poll_interval, poll)
+    UIManager:scheduleIn(self.poll_interval, self.poll_task)
     logger.info("BluetoothKeyBindings: Poll task scheduled with interval:", self.poll_interval)
 end
 
 ---
 --- Stops polling for Bluetooth input events.
+--- Unschedules the stored poll callback, if one is running.
 function BluetoothKeyBindings:stopPolling()
     if self.poll_task then
         UIManager:unschedule(self.poll_task)

--- a/src/kobo_bluetooth.lua
+++ b/src/kobo_bluetooth.lua
@@ -990,13 +990,19 @@ end
 
 ---
 --- Called when device is suspended.
---- Turns off Bluetooth before suspend.
+--- Always stops polling and monitors, then turns Bluetooth off if it is enabled.
 function KoboBluetooth:onSuspend()
     logger.dbg("KoboBluetooth: onSuspend")
 
     self.bluetooth_was_enabled_before_suspend = false
 
-    if self:isDeviceSupported() and self:isBluetoothEnabled() then
+    if not self:isDeviceSupported() then
+        return
+    end
+
+    self:_cleanup(false)
+
+    if self:isBluetoothEnabled() then
         self.bluetooth_was_enabled_before_suspend = true
         self:turnBluetoothOff(false)
     end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Triage of #229: the report has **strong merit**. The crashlog analysis is right about the KOReader scheduler API, and that bug can keep the UI loop waking at 20 Hz (and multiply those loops on reconnect).

### What #229 claimed

1. `BluetoothKeyBindings:startPolling()` stores `self.poll_task = UIManager:scheduleIn(...)`.
2. KOReader’s `UIManager:scheduleIn` returns nothing, so `poll_task` stays `nil`.
3. `stopPolling()` cannot unschedule the callback, so loops leak across reconnect / re-init.
4. `onSuspend()` only tears down Bluetooth when the radio is still reported on, so leftover tasks can keep running.

### KOReader validation

From [frontend/ui/uimanager.lua](https://github.com/koreader/koreader/blob/master/frontend/ui/uimanager.lua):

- `scheduleIn()` calls `schedule()` and **does not return a value**.
- `unschedule(action)` removes queue entries by **function identity** (`_task_queue[i].action == action`).
- `tickAfterNext()` is the API that *does* return a wrapper specifically so callers can unschedule it.
- The event loop sets its wait deadline from the next scheduled task, so a 50 ms (`poll_interval = 0.05`) task prevents long idle / standby while KOReader is awake.

`DbusMonitor` already used the correct pattern (store the callback, unschedule that function). The test mock of `scheduleIn` returned a numeric id, which is why unit tests never caught this.

### Fix

- Store the poll callback itself and pass that same function to `scheduleIn` / `unschedule`.
- Always `_cleanup()` on suspend, even if the radio is already off.
- Tests that mock KOReader’s void `scheduleIn` and the suspend cleanup path.

## Test plan

- [x] `busted spec/bluetooth_keybindings_spec.lua spec/kobo_bluetooth_spec.lua`
- [x] `luacheck` / `stylua` on touched files
- [ ] Full `busted spec/` in CI

Fixes #229

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea9ecc03-b00d-499d-b89c-a8755c543f09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea9ecc03-b00d-499d-b89c-a8755c543f09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

